### PR TITLE
Keep only addressId, addressType and receiverName when geolocation autotocompleted

### DIFF
--- a/src/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
+++ b/src/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
@@ -16,9 +16,6 @@ Object {
     "geolocationAutoCompleted": true,
     "value": "Rio de Janeiro",
   },
-  "complement": Object {
-    "value": null,
-  },
   "country": Object {
     "geolocationAutoCompleted": true,
     "value": "BRA",
@@ -47,9 +44,6 @@ Object {
     "focus": true,
     "reason": "ERROR_EMPTY_FIELD",
     "valid": false,
-    "value": null,
-  },
-  "reference": Object {
     "value": null,
   },
   "state": Object {

--- a/src/geolocation/geolocationAutoCompleteAddress.js
+++ b/src/geolocation/geolocationAutoCompleteAddress.js
@@ -21,7 +21,12 @@ export default function geolocationAutoCompleteAddress(
     setCountry,
     setAddressQuery,
     address => addNewField(address, 'geolocationAutoCompleted', true),
-    address => ({ ...baseAddress, ...address }),
+    address => ({
+      ...address,
+      addressId: baseAddress.addressId,
+      addressType: baseAddress.addressType,
+      receiverName: baseAddress.receiverName,
+    }),
     address => addFocusToNextInvalidField(address, rules),
   ])()
 

--- a/src/geolocation/geolocationAutoCompleteAddress.test.js
+++ b/src/geolocation/geolocationAutoCompleteAddress.test.js
@@ -38,15 +38,39 @@ describe('Geolocation Auto Complete Address', () => {
     expect(address.postalCode.focus).toBe(true)
   })
 
-  it('should not override receiverName', () => {
+  it('should keep addressId, addressType and receiverName', () => {
+    const addressId = '1'
+    const addressType = 'residential'
     const receiverName = 'Linus'
 
     const address = geolocationAutoCompleteAddress(
-      { ...newAddress, receiverName: { value: receiverName } },
+      {
+        ...newAddress,
+        addressId: { value: addressId },
+        addressType: { value: addressType },
+        receiverName: { value: receiverName },
+      },
       postalCodeGoogleAddress,
       usePostalCode
     )
 
+    expect(address.addressId.value).toBe(addressId)
+    expect(address.addressType.value).toBe(addressType)
     expect(address.receiverName.value).toBe(receiverName)
+  })
+
+  it('should remove fields that are not auto completed', () => {
+    const complement = 'apt 505'
+
+    const address = geolocationAutoCompleteAddress(
+      {
+        ...newAddress,
+        complement: { value: complement },
+      },
+      postalCodeGoogleAddress,
+      usePostalCode
+    )
+
+    expect(address.complement).toBeUndefined()
   })
 })


### PR DESCRIPTION

Fix #37