### PR TITLE
Add "id" and "type" props to InputText

### DIFF
--- a/src/DefaultInput/InputText.js
+++ b/src/DefaultInput/InputText.js
@@ -10,6 +10,7 @@ class InputText extends Component {
 
   render() {
     const { address, field, disabled, inputRef, placeholder, type } = this.props
+    const id = this.props.id.replace('{{fieldName}}', field.name)
     const fieldValue = address[field.name]
     const loading = !!address[field.name].loading
 
@@ -21,8 +22,8 @@ class InputText extends Component {
 
     return (
       <input
+        id={id}
         type={type}
-        id={`ship-${field.name}`}
         name={field.name}
         maxLength={field.maxLength}
         value={fieldValue.value || ''}
@@ -38,20 +39,22 @@ class InputText extends Component {
 }
 
 InputText.defaultProps = {
+  id: 'ship-{{fieldName}}',
+  type: 'text',
   className: '',
   disabled: false,
-  type: 'text',
 }
 
 InputText.propTypes = {
   field: PropTypes.object.isRequired,
-  className: PropTypes.string,
-  placeholder: PropTypes.string,
   address: AddressShapeWithValidation,
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
+  id: PropTypes.string,
   type: PropTypes.string,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
+  placeholder: PropTypes.string,
   inputRef: PropTypes.func,
 }
 

--- a/src/DefaultInput/InputText.test.js
+++ b/src/DefaultInput/InputText.test.js
@@ -59,4 +59,24 @@ describe('InputText', () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  it('should render different id', () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      id: 'summary-postal-code',
+    }
+    const tree = renderer.create(<InputText {...props} />).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should render different id based on fieldName', () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      id: 'my-context-{{fieldName}}',
+    }
+    const tree = renderer.create(<InputText {...props} />).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/src/DefaultInput/__snapshots__/InputText.test.js.snap
+++ b/src/DefaultInput/__snapshots__/InputText.test.js.snap
@@ -30,6 +30,36 @@ exports[`InputText should render default case 1`] = `
 />
 `;
 
+exports[`InputText should render different id 1`] = `
+<input
+  className="input-small error"
+  disabled={false}
+  id="summary-postal-code"
+  maxLength="9"
+  name="postalCode"
+  onBlur={[Function]}
+  onChange={[Function]}
+  placeholder={undefined}
+  type="text"
+  value=""
+/>
+`;
+
+exports[`InputText should render different id based on fieldName 1`] = `
+<input
+  className="input-small error"
+  disabled={false}
+  id="my-context-postalCode"
+  maxLength="9"
+  name="postalCode"
+  onBlur={[Function]}
+  onChange={[Function]}
+  placeholder={undefined}
+  type="text"
+  value=""
+/>
+`;
+
 exports[`InputText should render different input type 1`] = `
 <input
   className="input-small error"


### PR DESCRIPTION
Allow `<InputText id="summary-postal-code" type="tel" {...props} />`, for example.

Also added some snapshot tests to InputText.