### PR TITLE
Add inputExtraProps as a option to PostalCodeGetter and its sub components

### DIFF
--- a/src/InputFieldContainer.js
+++ b/src/InputFieldContainer.js
@@ -22,7 +22,7 @@ class InputFieldContainer extends Component {
         }
         return cleanAddress
       },
-      {}
+      {},
     )
   }
 
@@ -90,7 +90,14 @@ class InputFieldContainer extends Component {
   }
 
   render() {
-    const { Input, field, address, options, rules } = this.props
+    const {
+      Input,
+      field,
+      address,
+      options,
+      rules,
+      inputExtraProps,
+    } = this.props
 
     const _options =
       options ||
@@ -106,6 +113,7 @@ class InputFieldContainer extends Component {
         onChange={this.bindOnChange(field)}
         onBlur={this.bindOnBlur(field)}
         inputRef={this.inputRef}
+        {...inputExtraProps}
       />
     )
   }
@@ -117,6 +125,7 @@ InputFieldContainer.propTypes = {
   address: AddressShapeWithValidation,
   rules: PropTypes.object.isRequired,
   options: PropTypes.array,
+  inputExtraProps: PropTypes.object,
   onChangeAddress: PropTypes.func.isRequired,
 }
 

--- a/src/InputFieldContainer.test.js
+++ b/src/InputFieldContainer.test.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { shallow } from 'enzyme'
+
+import InputFieldContainer from './InputFieldContainer'
+import DefaultInput from './DefaultInput'
+import usePostalCode from './country/__mocks__/usePostalCode'
+import address from './__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from './__mocks__/inputExtraProps'
+
+describe('InputFieldContainer', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div')
+    const handleChange = jest.fn()
+
+    ReactDOM.render(
+      <InputFieldContainer
+        Input={DefaultInput}
+        field={{ name: 'postalCode' }}
+        address={address}
+        rules={usePostalCode}
+        options={[]}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+        onChangeAddress={handleChange}
+      />,
+      div,
+    )
+  })
+
+  it('render InputFieldContainer and checks for inputExtraProps', () => {
+    const handleChange = jest.fn()
+
+    const wrapper = shallow(
+      <InputFieldContainer
+        Input={DefaultInput}
+        field={{ name: 'postalCode' }}
+        address={address}
+        rules={usePostalCode}
+        options={[]}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+        onChangeAddress={handleChange}
+      />,
+    )
+
+    expect(wrapper.find(DefaultInput).props()).toMatchObject(INPUT_EXTRA_PROPS)
+  })
+})

--- a/src/PostalCodeGetter.js
+++ b/src/PostalCodeGetter.js
@@ -11,7 +11,13 @@ import { getField } from './selectors/fields'
 
 class PostalCodeGetter extends Component {
   render() {
-    const { address, rules, onChangeAddress, Input } = this.props
+    const {
+      address,
+      rules,
+      onChangeAddress,
+      Input,
+      inputExtraProps,
+    } = this.props
 
     switch (rules.postalCodeFrom) {
       case THREE_LEVELS:
@@ -21,6 +27,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            inputExtraProps={inputExtraProps}
           />
         )
       case TWO_LEVELS:
@@ -30,6 +37,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            inputExtraProps={inputExtraProps}
           />
         )
       case ONE_LEVEL:
@@ -39,6 +47,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            inputExtraProps={inputExtraProps}
           />
         )
       default:
@@ -51,6 +60,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            inputExtraProps={inputExtraProps}
           />
         )
       }
@@ -66,6 +76,7 @@ PostalCodeGetter.propTypes = {
   Input: PropTypes.func,
   address: AddressShapeWithValidation,
   rules: PropTypes.object.isRequired,
+  inputExtraProps: PropTypes.object,
   onChangeAddress: PropTypes.func.isRequired,
 }
 

--- a/src/PostalCodeGetter.test.js
+++ b/src/PostalCodeGetter.test.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { shallow } from 'enzyme'
 import PostalCodeGetter from './PostalCodeGetter'
 import address from './__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from './__mocks__/inputExtraProps'
 import usePostalCode from './country/__mocks__/usePostalCode'
 import useOneLevel from './country/__mocks__/useOneLevel'
 import useTwoLevels from './country/__mocks__/useTwoLevels'
@@ -18,7 +19,7 @@ describe('PostalCodeGetter', () => {
         rules={usePostalCode}
         onChangeAddress={jest.fn()}
       />,
-      div
+      div,
     )
   })
 
@@ -30,10 +31,27 @@ describe('PostalCodeGetter', () => {
         address={address}
         rules={usePostalCode}
         onChangeAddress={handleChange}
-      />
+      />,
     )
 
     expect(wrapper.find('InputFieldContainer')).toHaveLength(1)
+  })
+
+  it('render PostalCode and check for inputExtraProps', () => {
+    const handleChange = jest.fn()
+
+    const wrapper = shallow(
+      <PostalCodeGetter
+        address={address}
+        rules={usePostalCode}
+        onChangeAddress={handleChange}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />,
+    )
+
+    expect(wrapper.find('InputFieldContainer').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 
   it('render OneLevel', () => {
@@ -44,10 +62,27 @@ describe('PostalCodeGetter', () => {
         address={address}
         rules={useOneLevel}
         onChangeAddress={handleChange}
-      />
+      />,
     )
 
     expect(wrapper.find('OneLevel')).toHaveLength(1)
+  })
+
+  it('render OneLevel and check for inputExtraProps', () => {
+    const handleChange = jest.fn()
+
+    const wrapper = shallow(
+      <PostalCodeGetter
+        address={address}
+        rules={useOneLevel}
+        onChangeAddress={handleChange}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />,
+    )
+
+    expect(wrapper.find('OneLevel').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 
   it('render TwoLevels', () => {
@@ -58,10 +93,27 @@ describe('PostalCodeGetter', () => {
         address={address}
         rules={useTwoLevels}
         onChangeAddress={handleChange}
-      />
+      />,
     )
 
     expect(wrapper.find('TwoLevels')).toHaveLength(1)
+  })
+
+  it('render TwoLevels and check for inputExtraProps', () => {
+    const handleChange = jest.fn()
+
+    const wrapper = shallow(
+      <PostalCodeGetter
+        address={address}
+        rules={useTwoLevels}
+        onChangeAddress={handleChange}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />,
+    )
+
+    expect(wrapper.find('TwoLevels').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 
   it('render ThreeLevels', () => {
@@ -72,9 +124,26 @@ describe('PostalCodeGetter', () => {
         address={address}
         rules={useThreeLevels}
         onChangeAddress={handleChange}
-      />
+      />,
     )
 
     expect(wrapper.find('ThreeLevels')).toHaveLength(1)
+  })
+
+  it('render ThreeLevels and check for inputExtraProps', () => {
+    const handleChange = jest.fn()
+
+    const wrapper = shallow(
+      <PostalCodeGetter
+        address={address}
+        rules={useThreeLevels}
+        onChangeAddress={handleChange}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />,
+    )
+
+    expect(wrapper.find('ThreeLevels').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 })

--- a/src/__mocks__/inputExtraProps.js
+++ b/src/__mocks__/inputExtraProps.js
@@ -1,0 +1,7 @@
+const INPUT_EXTRA_PROPS = {
+  a: 10,
+  b: 'bbb',
+  c: () => 'done',
+}
+
+export default INPUT_EXTRA_PROPS

--- a/src/postalCodeFrom/OneLevel.js
+++ b/src/postalCodeFrom/OneLevel.js
@@ -5,7 +5,13 @@ import SelectPostalCode from './SelectPostalCode'
 
 class OneLevel extends Component {
   render() {
-    const { address, rules, onChangeAddress, Input } = this.props
+    const {
+      address,
+      rules,
+      onChangeAddress,
+      Input,
+      inputExtraProps,
+    } = this.props
 
     return (
       <div>
@@ -14,6 +20,7 @@ class OneLevel extends Component {
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
+          inputExtraProps={inputExtraProps}
         />
       </div>
     )
@@ -23,6 +30,7 @@ class OneLevel extends Component {
 OneLevel.propTypes = {
   Input: PropTypes.func.isRequired,
   address: AddressShapeWithValidation,
+  inputExtraProps: PropTypes.object,
   rules: PropTypes.object.isRequired,
   onChangeAddress: PropTypes.func.isRequired,
 }

--- a/src/postalCodeFrom/OneLevel.test.js
+++ b/src/postalCodeFrom/OneLevel.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import OneLevel from './OneLevel'
 import useOneLevel from '../country/__mocks__/useOneLevel'
 import address from '../__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from '../__mocks__/inputExtraProps'
 import MockInput from '../DefaultInput/__mocks__/Input'
 
 describe('OneLevel', () => {
@@ -13,6 +14,20 @@ describe('OneLevel', () => {
         address={address}
         rules={useOneLevel}
         onChangeAddress={jest.fn()}
+      />
+    )
+
+    expect(wrapper.find('SelectPostalCode')).toHaveLength(1)
+  })
+
+  it('render it right with inputExtraProps', () => {
+    const wrapper = shallow(
+      <OneLevel
+        Input={MockInput}
+        address={address}
+        rules={useOneLevel}
+        onChangeAddress={jest.fn()}
+        inputExtraProps={INPUT_EXTRA_PROPS}
       />
     )
 

--- a/src/postalCodeFrom/SelectLevel.js
+++ b/src/postalCodeFrom/SelectLevel.js
@@ -6,7 +6,14 @@ import InputFieldContainer from '../InputFieldContainer'
 
 class SelectLevel extends Component {
   render() {
-    const { level, rules, address, Input, onChangeAddress } = this.props
+    const {
+      level,
+      rules,
+      address,
+      Input,
+      onChangeAddress,
+      inputExtraProps,
+    } = this.props
     const field = getLevelField(level, rules)
 
     return (
@@ -16,6 +23,7 @@ class SelectLevel extends Component {
         address={address}
         rules={rules}
         onChangeAddress={onChangeAddress}
+        inputExtraProps={inputExtraProps}
       />
     )
   }
@@ -26,6 +34,7 @@ SelectLevel.propTypes = {
   level: PropTypes.oneOf([0, 1]),
   address: AddressShapeWithValidation,
   rules: PropTypes.object.isRequired,
+  inputExtraProps: PropTypes.object,
   onChangeAddress: PropTypes.func.isRequired,
 }
 

--- a/src/postalCodeFrom/SelectLevel.test.js
+++ b/src/postalCodeFrom/SelectLevel.test.js
@@ -3,6 +3,7 @@ import SelectLevel from './SelectLevel'
 import { shallow, mount } from 'enzyme'
 import useThreeLevels from '../country/__mocks__/useThreeLevels'
 import address from '../__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from '../__mocks__/inputExtraProps'
 import MockInput from '../DefaultInput/__mocks__/Input'
 
 describe('SelectLevel', () => {
@@ -14,10 +15,27 @@ describe('SelectLevel', () => {
         address={address}
         rules={useThreeLevels}
         onChangeAddress={jest.fn()}
-      />
+      />,
     )
 
     expect(wrapper.find('InputFieldContainer')).toHaveLength(1)
+  })
+
+  it('render it right with inputExtraProps', () => {
+    const wrapper = shallow(
+      <SelectLevel
+        level={0}
+        Input={MockInput}
+        address={address}
+        rules={useThreeLevels}
+        onChangeAddress={jest.fn()}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />,
+    )
+
+    expect(wrapper.find('InputFieldContainer').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 
   it('should call handleChange', () => {
@@ -34,7 +52,7 @@ describe('SelectLevel', () => {
         address={address}
         rules={useThreeLevels}
         onChangeAddress={handleChange}
-      />
+      />,
     )
 
     expect(handleChange).toHaveBeenCalled()
@@ -59,7 +77,7 @@ describe('SelectLevel', () => {
         }}
         rules={useThreeLevels}
         onChangeAddress={handleChange}
-      />
+      />,
     )
 
     expect(handleChange).toHaveBeenCalledWith({

--- a/src/postalCodeFrom/SelectPostalCode.js
+++ b/src/postalCodeFrom/SelectPostalCode.js
@@ -35,20 +35,19 @@ class SelectPostalCode extends Component {
   }
 
   getOptions(fieldName, address, rules) {
-    return getPostalCodeOptions(
-      address,
-      rules
-    ).map(({ postalCode, label }) => ({
-      label,
-      value: this.composeValue(fieldName, {
-        [fieldName]: { value: label },
-        postalCode: { value: postalCode },
+    return getPostalCodeOptions(address, rules).map(
+      ({ postalCode, label }) => ({
+        label,
+        value: this.composeValue(fieldName, {
+          [fieldName]: { value: label },
+          postalCode: { value: postalCode },
+        }),
       }),
-    }))
+    )
   }
 
   render() {
-    const { address, rules, Input } = this.props
+    const { address, rules, Input, inputExtraProps } = this.props
     const currentLevelField = getLastLevelField(rules)
     const fieldName = currentLevelField.name
 
@@ -68,6 +67,7 @@ class SelectPostalCode extends Component {
         options={this.getOptions(fieldName, address, rules)}
         rules={rules}
         onChangeAddress={this.handleChange}
+        inputExtraProps={inputExtraProps}
       />
     )
   }
@@ -76,6 +76,7 @@ class SelectPostalCode extends Component {
 SelectPostalCode.propTypes = {
   Input: PropTypes.func.isRequired,
   address: AddressShapeWithValidation.isRequired,
+  inputExtraProps: PropTypes.object,
   rules: PropTypes.object.isRequired,
   onChangeAddress: PropTypes.func.isRequired,
 }

--- a/src/postalCodeFrom/SelectPostalCode.test.js
+++ b/src/postalCodeFrom/SelectPostalCode.test.js
@@ -3,6 +3,7 @@ import { shallow, mount } from 'enzyme'
 import SelectPostalCode from './SelectPostalCode'
 import useOneLevel from '../country/__mocks__/useOneLevel'
 import address from '../__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from '../__mocks__/inputExtraProps'
 import find from 'lodash/find'
 
 describe('SelectPostalCode', () => {
@@ -35,6 +36,28 @@ describe('SelectPostalCode', () => {
       field: firstLevelField,
       options: expect.any(Array),
       onChangeAddress: expect.any(Function),
+    })
+  })
+
+  it('should render InputFieldContainer with the right props and inputExtraProps', () => {
+    const wrapper = shallow(
+      <SelectPostalCode
+        Input={MockInput}
+        address={address}
+        rules={useOneLevel}
+        onChangeAddress={jest.fn()}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />
+    )
+
+    const props = wrapper.find('InputFieldContainer').props()
+
+    expect(props).toMatchObject({
+      address,
+      field: firstLevelField,
+      options: expect.any(Array),
+      onChangeAddress: expect.any(Function),
+      inputExtraProps: INPUT_EXTRA_PROPS,
     })
   })
 

--- a/src/postalCodeFrom/ThreeLevels.js
+++ b/src/postalCodeFrom/ThreeLevels.js
@@ -6,7 +6,13 @@ import SelectPostalCode from './SelectPostalCode'
 
 class ThreeLevels extends Component {
   render() {
-    const { address, rules, Input, onChangeAddress } = this.props
+    const {
+      address,
+      rules,
+      Input,
+      onChangeAddress,
+      inputExtraProps,
+    } = this.props
 
     return (
       <div>
@@ -16,6 +22,7 @@ class ThreeLevels extends Component {
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
+          inputExtraProps={inputExtraProps}
         />
         <SelectLevel
           level={1}
@@ -23,12 +30,14 @@ class ThreeLevels extends Component {
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
+          inputExtraProps={inputExtraProps}
         />
         <SelectPostalCode
           Input={Input}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
+          inputExtraProps={inputExtraProps}
         />
       </div>
     )
@@ -38,6 +47,7 @@ class ThreeLevels extends Component {
 ThreeLevels.propTypes = {
   Input: PropTypes.func.isRequired,
   address: AddressShapeWithValidation,
+  inputExtraProps: PropTypes.object,
   rules: PropTypes.object.isRequired,
   onChangeAddress: PropTypes.func.isRequired,
 }

--- a/src/postalCodeFrom/ThreeLevels.test.js
+++ b/src/postalCodeFrom/ThreeLevels.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import ThreeLevels from './ThreeLevels'
 import useThreeLevels from '../country/__mocks__/useThreeLevels'
 import address from '../__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from '../__mocks__/inputExtraProps'
 import MockInput from '../DefaultInput/__mocks__/Input'
 
 describe('ThreeLevels', () => {
@@ -18,5 +19,27 @@ describe('ThreeLevels', () => {
 
     expect(wrapper.find('SelectLevel')).toHaveLength(2)
     expect(wrapper.find('SelectPostalCode')).toHaveLength(1)
+  })
+
+  it('without first and second level selected and with inputExtraProps', () => {
+    const wrapper = shallow(
+      <ThreeLevels
+        Input={MockInput}
+        address={address}
+        rules={useThreeLevels}
+        onChangeAddress={jest.fn()}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />
+    )
+
+    expect(wrapper.find('SelectLevel').first().prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
+    expect(wrapper.find('SelectLevel').last().prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
+    expect(wrapper.find('SelectPostalCode').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 })

--- a/src/postalCodeFrom/TwoLevels.js
+++ b/src/postalCodeFrom/TwoLevels.js
@@ -6,7 +6,13 @@ import SelectPostalCode from './SelectPostalCode'
 
 class TwoLevels extends Component {
   render() {
-    const { address, rules, Input, onChangeAddress } = this.props
+    const {
+      address,
+      rules,
+      Input,
+      onChangeAddress,
+      inputExtraProps,
+    } = this.props
 
     return (
       <div>
@@ -16,12 +22,14 @@ class TwoLevels extends Component {
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
+          inputExtraProps={inputExtraProps}
         />
         <SelectPostalCode
           Input={Input}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
+          inputExtraProps={inputExtraProps}
         />
       </div>
     )
@@ -32,6 +40,7 @@ TwoLevels.propTypes = {
   Input: PropTypes.func.isRequired,
   address: AddressShapeWithValidation,
   rules: PropTypes.object.isRequired,
+  inputExtraProps: PropTypes.object,
   onChangeAddress: PropTypes.func.isRequired,
 }
 

--- a/src/postalCodeFrom/TwoLevels.test.js
+++ b/src/postalCodeFrom/TwoLevels.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import TwoLevels from './TwoLevels'
 import useTwoLevels from '../country/__mocks__/useTwoLevels'
 import address from '../__mocks__/newAddress'
+import INPUT_EXTRA_PROPS from '../__mocks__/inputExtraProps'
 import MockInput from '../DefaultInput/__mocks__/Input'
 
 describe('TwoLevels', () => {
@@ -13,10 +14,29 @@ describe('TwoLevels', () => {
         address={address}
         rules={useTwoLevels}
         onChangeAddress={jest.fn()}
-      />
+      />,
     )
 
     expect(wrapper.find('SelectLevel')).toHaveLength(1)
     expect(wrapper.find('SelectPostalCode')).toHaveLength(1)
+  })
+
+  it('render it right with inputExtraProps', () => {
+    const wrapper = shallow(
+      <TwoLevels
+        Input={MockInput}
+        address={address}
+        rules={useTwoLevels}
+        onChangeAddress={jest.fn()}
+        inputExtraProps={INPUT_EXTRA_PROPS}
+      />,
+    )
+
+    expect(wrapper.find('SelectLevel').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
+    expect(wrapper.find('SelectPostalCode').prop('inputExtraProps')).toEqual(
+      INPUT_EXTRA_PROPS,
+    )
   })
 })


### PR DESCRIPTION
Check the `InputFieldContainer.test.js` and `PostalCodeGetter.test.js` to understand this PR better.

But I want to be able to do:
```js
<PostalCodeGetter
  Input={MyInput}
  inputExtraProps={{ myCustomProp: 'XYZ', myCustomCallback: () => {...} }}
/>
```

And receive this props on `MyInput` component to do some custom logic, like control the submit behavior of the form