### PR TITLE
Handle case of postal code autocompleting a field with more than one option

### DIFF
--- a/src/AutoCompletedFields.js
+++ b/src/AutoCompletedFields.js
@@ -23,29 +23,23 @@ class AutoCompletedFields extends Component {
     const { address, onChangeAddress } = this.props
 
     onChangeAddress(removeAutoCompletedFields(address))
-  }
-
-  hasAutoCompletedField(address) {
-    return find(
-      address,
-      field => field.postalCodeAutoCompleted || field.geolocationAutoCompleted,
-    )
-  }
+  };
 
   filterRelevantFields(address) {
     return pickBy(address, (field, name) => {
-      const autoCompleted =
-        field.postalCodeAutoCompleted || field.geolocationAutoCompleted
+      const autoCompleted = field.postalCodeAutoCompleted ||
+        field.geolocationAutoCompleted
 
-      const postalCodeGeolocationAutoCompleted =
-        name !== 'postalCode' ||
+      const postalCodeGeolocationAutoCompleted = name !== 'postalCode' ||
         (name === 'postalCode' && field.geolocationAutoCompleted)
 
       const isRelevantField = IRRELEVANT_FIELDS.indexOf(name) === -1
+      const hasValue = address[name].value && address[name].value.length > 0
 
-      return (
-        autoCompleted && postalCodeGeolocationAutoCompleted && isRelevantField
-      )
+      return autoCompleted &&
+        hasValue &&
+        postalCodeGeolocationAutoCompleted &&
+        isRelevantField
     })
   }
 
@@ -55,10 +49,6 @@ class AutoCompletedFields extends Component {
 
   render() {
     const { address, rules, children } = this.props
-
-    if (this.hasAutoCompletedField(address) === undefined) {
-      return null
-    }
 
     const filteredAddress = this.filterRelevantFields(address)
 
@@ -78,11 +68,9 @@ class AutoCompletedFields extends Component {
         rules={rules}
       >
         <span> - </span>
-        {React.Children.map(children, child =>
-          React.cloneElement(child, {
-            onClick: this.handleClickChange,
-          }),
-        )}
+        {React.Children.map(children, child => React.cloneElement(child, {
+          onClick: this.handleClickChange,
+        }))}
       </AddressSummary>
     )
   }
@@ -95,8 +83,5 @@ AutoCompletedFields.propTypes = {
   onChangeAddress: PropTypes.func.isRequired,
 }
 
-const enhance = compose(
-  injectAddressContext,
-  injectRules,
-)
+const enhance = compose(injectAddressContext, injectRules)
 export default enhance(AutoCompletedFields)

--- a/src/AutoCompletedFields.test.js
+++ b/src/AutoCompletedFields.test.js
@@ -15,7 +15,7 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={jest.fn()}
       >
         {children}
-      </AutoCompletedFields>,
+      </AutoCompletedFields>
     )
   })
 
@@ -27,7 +27,27 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={jest.fn()}
       >
         {children}
-      </AutoCompletedFields>,
+      </AutoCompletedFields>
+    )
+    expect(wrapper.html()).toBe(null)
+  })
+
+  it('should display nothing if there are autocompleted fields with no value', () => {
+    const wrapper = mount(
+      <AutoCompletedFields
+        rules={usePostalCode}
+        address={{
+          ...newAddress,
+          state: {
+            postalCodeAutoCompleted: true,
+            value: null,
+            valueOptions: ['Buenos Aires', 'Entre Ríos'],
+          },
+        }}
+        onChangeAddress={jest.fn()}
+      >
+        {children}
+      </AutoCompletedFields>
     )
     expect(wrapper.html()).toBe(null)
   })
@@ -53,7 +73,7 @@ describe('AutoCompletedFields', () => {
           onChangeAddress={onChangeAddress}
         >
           {children}
-        </AutoCompletedFields>,
+        </AutoCompletedFields>
       )
     })
 
@@ -84,12 +104,12 @@ describe('AutoCompletedFields', () => {
       expect(onChangeAddressArgument.state).toHaveProperty('value', state)
       expect(onChangeAddressArgument.state).toHaveProperty(
         'geolocationAutoCompleted',
-        undefined,
+        undefined
       )
       expect(onChangeAddressArgument.city).toHaveProperty('value', city)
       expect(onChangeAddressArgument.state).toHaveProperty(
         'postalCodeAutoCompleted',
-        undefined,
+        undefined
       )
     })
 
@@ -117,7 +137,7 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={onChangeAddress}
       >
         {children}
-      </AutoCompletedFields>,
+      </AutoCompletedFields>
     )
 
     const AddressSummary = wrapper.find('AddressSummary')
@@ -145,7 +165,7 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={onChangeAddress}
       >
         {children}
-      </AutoCompletedFields>,
+      </AutoCompletedFields>
     )
 
     const AddressSummary = wrapper.find('AddressSummary')


### PR DESCRIPTION
Esse caso corrige o componente de AutoCompletedFields pra correcao que vem em seguida da issue: https://github.com/vtex/omnishipping/issues/826

Evita que isso aconteça:
![image](https://user-images.githubusercontent.com/284515/44168623-4eb16a80-a0a8-11e8-8f73-01844af581d5.png)

Mostre o componente sem nada dentro.