### PR TITLE
Fix delimiter condition to show in summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.10] - 2019-01-10
+
 ## [3.0.9] - 2019-01-10
 
 ## [3.0.8] - 2019-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.9] - 2019-01-10
+
 ## [3.0.8] - 2019-01-08
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/react/AddressSummary.js
+++ b/react/AddressSummary.js
@@ -59,6 +59,8 @@ class AddressSummary extends Component {
 
               const hasNextField = index + 1 < summary.length &&
                 address[summary[index + 1].name]
+              const hasDifferentDelimiter = field.delimiterAfter !== '-'
+              const shouldShowDelimiter = hasNextField || hasDifferentDelimiter
 
               return address[field.name]
                 ? <span key={field.name}>
@@ -69,7 +71,7 @@ class AddressSummary extends Component {
                       </span>}
                   <span className={field.name}>{address[field.name]}</span>
                   {field.delimiterAfter &&
-                      hasNextField &&
+                      shouldShowDelimiter &&
                       <span className={field.name + '-delimiter-after'}>
                         {field.delimiterAfter}
                       </span>}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix delimiter after in address summary.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
