### PR TITLE
Add focus and reason to shallow fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `focus` and `reason` to shallow fields for components to update theses props
+
 ## [3.4.0] - 2019-02-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.4.1] - 2019-02-13
+
 ### Fixed
 
 - Added `focus` and `reason` to shallow fields for components to update theses props

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/react/pureInputField.js
+++ b/react/pureInputField.js
@@ -22,6 +22,8 @@ const SHALLOW_FIELDS = [
   'autoCompleted',
   'loading',
   'value',
+  'focus',
+  'reason',
   'valueOptions',
   'notApplicable',
   'disabled',


### PR DESCRIPTION
https://app.clubhouse.io/vtex-dev/story/5353/informa%C3%A7%C3%A3o-sobre-campo-obrigat%C3%B3rio-no-campo-n%C3%BAmero

#### What is the purpose of this pull request?
Added `focus` and `reason` to shallow fields for components to update theses props

#### What problem is this solving?
Errors would not show after address changes.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)