### PR TITLE
Fix getting already filled multiple levels postal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Getting already filled multiple levels postal code due to the API sets strings uppercase
+
 ## [3.4.2] - 2019-02-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.4.3] - 2019-02-14
+
 ### Fixed
 
 - Getting already filled multiple levels postal code due to the API sets strings uppercase

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/react/selectors/fields.js
+++ b/react/selectors/fields.js
@@ -27,7 +27,7 @@ function getFieldValue(field) {
   return typeof field === 'object' ? field.value : field
 }
 
-function normalizeOptions(options) {
+export function normalizeOptions(options) {
   return reduce(
     options,
     (acc, option, key) => {

--- a/react/selectors/postalCode.js
+++ b/react/selectors/postalCode.js
@@ -1,6 +1,7 @@
 import { ONE_LEVEL, TWO_LEVELS, THREE_LEVELS } from '../constants'
-import { getField } from './fields'
+import { getField, normalizeOptions } from './fields'
 import last from 'lodash/last'
+import cleanStr from './cleanStr'
 
 export function getPostalCodeOptions(address, rules) {
   switch (rules.postalCodeFrom) {
@@ -20,11 +21,13 @@ function getOneLevelPostalCodes(address, rules) {
 
 function getTwoLevelsPostalCodes(address, rules) {
   const firstLevel = getField(rules.postalCodeLevels[0], rules)
+  const firstLevelValue = cleanStr(address[firstLevel.name].value)
+  const normalizedSecondLevelPostalCodes = normalizeOptions(rules.secondLevelPostalCodes)
 
   return address[firstLevel.name] &&
   address[firstLevel.name].value &&
-  rules.secondLevelPostalCodes[address[firstLevel.name].value]
-    ? rules.secondLevelPostalCodes[address[firstLevel.name].value]
+  normalizedSecondLevelPostalCodes[firstLevelValue]
+    ? normalizedSecondLevelPostalCodes[firstLevelValue]
     : []
 }
 
@@ -32,15 +35,18 @@ function getThreeLevelsPostalCodes(address, rules) {
   const firstLevel = getField(rules.postalCodeLevels[0], rules)
   const secondLevel = getField(rules.postalCodeLevels[1], rules)
 
+  const firstLevelValue = cleanStr(address[firstLevel.name].value)
+  const normalizedThirdLevelPostalCodes = normalizeOptions(rules.thirdLevelPostalCodes)
+
   return address[firstLevel.name] &&
-  address[firstLevel.name].value &&
+  firstLevelValue &&
   address[secondLevel.name] &&
   address[secondLevel.name].value &&
-  rules.thirdLevelPostalCodes[address[firstLevel.name].value] &&
-  rules.thirdLevelPostalCodes[address[firstLevel.name].value][
+  normalizedThirdLevelPostalCodes[firstLevelValue] &&
+  normalizedThirdLevelPostalCodes[firstLevelValue][
     address[secondLevel.name].value
   ]
-    ? rules.thirdLevelPostalCodes[address[firstLevel.name].value][
+    ? normalizedThirdLevelPostalCodes[firstLevelValue][
         address[secondLevel.name].value
       ]
     : []

--- a/react/selectors/postalCode.test.js
+++ b/react/selectors/postalCode.test.js
@@ -22,7 +22,7 @@ describe('Field Selectors', () => {
 
     it('with two levels', () => {
       const address = {
-        state: { value: 'I Región' },
+        state: { value: 'I REGIÓN' },
       }
 
       const postalCodes = getPostalCodeOptions(address, useTwoLevels)
@@ -38,7 +38,7 @@ describe('Field Selectors', () => {
 
     it('with three levels', () => {
       const address = {
-        state: { value: 'Beni' },
+        state: { value: 'BENI' },
         city: { value: 'Mamore' },
       }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Getting already filled multiple levels postal code due to fact that the API sets strings uppercase

#### What problem is this solving?
https://app.clubhouse.io/vtex-dev/story/5321/falha-no-endere%C3%A7o-de-recompra-para-pa%C3%ADses-sem-postalcode

#### How should this be manually tested?
`yarn test`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)