### PR TITLE
Add country restrictions when geolocation autocomplete address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.5.10] - 2019-05-16
+
 ### Added
 
 - Country restrictions when geolocation autocomplete address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Country restrictions when geolocation autocomplete address
+
 ## [3.5.9] - 2019-05-08
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.5.9",
+  "version": "3.5.10",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "3.5.9",
+  "version": "3.5.10",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/react/geolocation/GetAddressByGeolocation.test.js
+++ b/react/geolocation/GetAddressByGeolocation.test.js
@@ -10,10 +10,16 @@ describe('Get Address by Geolocation', () => {
       address: newAddress,
       onChangeAddress: jest.fn(),
       rules: useOneLevel,
-      googleMaps: {Geocoder: googleMaps(mockFn)},
+      googleMaps: { Geocoder: googleMaps(mockFn) },
     }
     const geolocationAddress = getAddressByGeolocation(geolocationProps)
 
-    expect(mockFn).toHaveBeenCalledWith({address: '321 Praia de Botafogo'}, expect.any(Function))
+    expect(mockFn).toHaveBeenCalledWith(
+      {
+        address: '321 Praia de Botafogo',
+        componentRestrictions: { country: 'EC' },
+      },
+      expect.any(Function),
+    )
   })
 })

--- a/react/geolocation/Utils.js
+++ b/react/geolocation/Utils.js
@@ -1,41 +1,44 @@
 import geolocationAutoCompleteAddress from './geolocationAutoCompleteAddress'
 
 export default function getAddressByGeolocation(geolocationProps) {
-  const {
-    address,
-    onChangeAddress,
-    rules,
-    googleMaps,
-  } = geolocationProps
+  const { address, onChangeAddress, rules, googleMaps } = geolocationProps
 
   if (!googleMaps || !address || !rules || !address['number'].value) {
     return
   }
 
   const geocoder = new googleMaps.Geocoder()
-  geocoder.geocode({ address: `${address['number'].value} ${address['street'].value}` }, (results, status) => {
-    if (status === googleMaps.GeocoderStatus.OK) {
-      if (results[0]) {
-        const googleAddress = results[0]
-        const autoCompletedAddress = geolocationAutoCompleteAddress(
-          address,
-          googleAddress,
-          rules
-        )
+  geocoder.geocode(
+    {
+      componentRestrictions: {
+        country: rules.abbr,
+      },
+      address: `${address['number'].value} ${address['street'].value}`,
+    },
+    (results, status) => {
+      if (status === googleMaps.GeocoderStatus.OK) {
+        if (results[0]) {
+          const googleAddress = results[0]
+          const autoCompletedAddress = geolocationAutoCompleteAddress(
+            address,
+            googleAddress,
+            rules.geolocation,
+          )
 
-        onChangeAddress({
-          ...autoCompletedAddress,
-          complement: {
-            value: null,
-          },
-          reference: {
-            value: null,
-          },
-        })
-        return autoCompletedAddress
+          onChangeAddress({
+            ...autoCompletedAddress,
+            complement: {
+              value: null,
+            },
+            reference: {
+              value: null,
+            },
+          })
+          return autoCompletedAddress
+        }
+      } else {
+        console.warn(`Google Maps Error: ${status}`)
       }
-    } else {
-      console.warn(`Google Maps Error: ${status}`)
-    }
-  })
+    },
+  )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Added

- Country restrictions when geolocation autocomplete address

#### What problem is this solving?
Closes https://app.clubhouse.io/vtex-dev/story/11685/falha-na-verifica%C3%A7%C3%A3o-reversa-de-endere%C3%A7o-com-gmaps

#### How should this be manually tested?
`yarn test`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)