### PR TITLE
Fixed passing rules to geolocationAutoCompleteAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Passing `rules` instead of `rules.geolocation` to `geolocationAutoCompleteAddress` since it uses the root object in the function
+
 ## [3.5.11] - 2019-05-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.5.12] - 2019-05-24
+
 ### Fixed
 
 - Passing `rules` instead of `rules.geolocation` to `geolocationAutoCompleteAddress` since it uses the root object in the function

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.5.11",
+  "version": "3.5.12",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,6 @@
   },
   "scripts": {
     "postreleasy": "vtex publish --public && npm publish"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "3.5.11",
+  "version": "3.5.12",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/react/geolocation/Utils.js
+++ b/react/geolocation/Utils.js
@@ -22,7 +22,7 @@ export default function getAddressByGeolocation(geolocationProps) {
           const autoCompletedAddress = geolocationAutoCompleteAddress(
             address,
             googleAddress,
-            rules.geolocation,
+            rules,
           )
 
           onChangeAddress({


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Fixed

- Passing `rules` instead of `rules.geolocation` to `geolocationAutoCompleteAddress` since it uses the root object in the function

function using it: https://github.com/vtex/address-form/blob/master/react/geolocation/geolocationAutoCompleteAddress.js#L14

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
