### PR TITLE
Update USA postal code regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- USA postal code regular expression to cover optional diplomatic pouch numbers
+
 ## [3.5.15] - 2019-07-03
 
 ### Changed

--- a/react/country/USA.js
+++ b/react/country/USA.js
@@ -18,7 +18,7 @@ export default {
       fixedLabel: 'ZIP',
       required: true,
       mask: '99999',
-      regex: '^([\\d]{5})$',
+      regex: '^([\\d]{5}((-)?[\\d]{4})?)$',
       postalCodeAPI: true,
       forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',
       size: 'small',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update USA postal code regex

#### What problem is this solving?
Closes https://app.clubhouse.io/vtex-dev/story/13195/alterar-regex-de-cep-dos-eua-para-acomodar-diplomatic-pouch-number

#### How should this be manually tested?
1. Add a global product to cart with this [link](https://usapostalcode--vtexgame1.myvtex.com/checkout/cart/add?&workspace=fernando&sku=312&qty=1&seller=1&sc=2)
2. Go to shipping
3. Change Country to `United States`
4. Type postal code `20521-9000` (Washington DC)

#### Screenshots or example usage
n/a

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
