### PR TITLE
Add translation to ROU in geolocation placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- ROU geolocation placeholder translation
+- ROU geolocation placeholder translation.
 
 ## [3.5.16] - 2019-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- ROU geolocation placeholder translation
+
 ## [3.5.16] - 2019-07-04
 
 ### Changed

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -21,6 +21,7 @@
   "address-form.geolocation.example.URY": "Ex: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Ex: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Ex: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Ex: Bulevardul Ion Mihalache, București 011192, Romania",
   "address-form.field.notApplicable": "S/N",
   "address-form.field.noNumber": "Sense nombre",
   "address-form.error.ERROR_EMPTY_FIELD": "Aquest és un camp obligatori.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,7 @@
   "address-form.geolocation.example.URY": "Eg: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Eg: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Eg: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Eg: Bulevardul Ion Mihalache, București 011192, Romania",
 
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "No number",

--- a/messages/es.json
+++ b/messages/es.json
@@ -22,6 +22,7 @@
   "address-form.geolocation.example.URY": "Ej: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Ej: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Ej: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Ej: Bulevardul Ion Mihalache, București 011192, Romania",
 
   "address-form.field.notApplicable": "S/N",
   "address-form.field.noNumber": "Sin numero",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -22,6 +22,7 @@
   "address-form.geolocation.example.URY": "Ex: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Ex: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Ex: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Ex: Bulevardul Ion Mihalache, București 011192, Romania",
 
   "address-form.field.notApplicable": "S/N",
   "address-form.field.noNumber": "Sans numéro",

--- a/messages/it.json
+++ b/messages/it.json
@@ -22,6 +22,7 @@
   "address-form.geolocation.example.URY": "Es: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Es: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Es: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Es: Bulevardul Ion Mihalache, București 011192, Romania",
 
   "address-form.field.notApplicable": "N/N",
   "address-form.field.noNumber": "Nessun numero",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -22,6 +22,7 @@
   "address-form.geolocation.example.URY": "Eg: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Eg: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Eg: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Eg: Bulevardul Ion Mihalache, București 011192, Romania",
 
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "Not applicable",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -22,6 +22,7 @@
   "address-form.geolocation.example.URY": "Ex: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Ex: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Ex: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Ex: Bulevardul Ion Mihalache, București 011192, Romania",
 
   "address-form.field.notApplicable": "S/N",
   "address-form.field.noNumber": "Sem número",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -21,6 +21,7 @@
   "address-form.geolocation.example.URY": "Eg: Bulevar Artigas, 1394, Montevidéu",
   "address-form.geolocation.example.USA": "Eg: 225 East 41st Street, New York",
   "address-form.geolocation.example.VEN": "Eg: Avenida Mohedano, Caracas",
+  "address-form.geolocation.example.ROU": "Eg: Bulevardul Ion Mihalache, București 011192, Romania",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "Fără număr",
   "address-form.error.ERROR_EMPTY_FIELD": "Acest câmp este obligatoriu.",


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

There were no translation for Romania geolocation placeholder.

#### How should this be manually tested?

Use the following workspace, log in to the my account and try to create an address. Check if the placeholder for the geolocation input has the placeholder with a romanian exemple.

https://www.f64.ro/_secure/account?workspace=arthur

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/11592617/61070626-8a060780-a3e5-11e9-97d4-958254cde34f.png)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
