### PR TITLE
Fix CHL postal code for city Aysén (v6)

### DIFF
--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -345,7 +345,7 @@ const countryData = {
     'San Pablo': '5350000',
   },
   'XI Región': {
-    Aysén: '6008102',
+    Aysén: '6000000',
     'Chile Chico': '6050000',
     Cisnes: '6010000',
     Cochrane: '6100000',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the CEP of the city "Aysén" (CHL). The correct CEP is 6000000. 
Ref: https://pt.youbianku.com/Chile

#### What problem is this solving?
In the selection of state and city, an incorrect CEP was being returned.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
