### PR TITLE
Keep valid fields valid if they are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep valid fields valid if they are valid
+
 ## [3.5.18] - 2019-07-24
 
 ## [3.5.17] - 2019-07-15

--- a/react/AutoCompletedFields.test.js
+++ b/react/AutoCompletedFields.test.js
@@ -29,7 +29,7 @@ describe('AutoCompletedFields', () => {
         {children}
       </AutoCompletedFields>
     )
-    expect(wrapper.html()).toBe(null)
+    expect(wrapper.html()).toBe('')
   })
 
   it('should display nothing if there are autocompleted fields with no value', () => {
@@ -49,7 +49,7 @@ describe('AutoCompletedFields', () => {
         {children}
       </AutoCompletedFields>
     )
-    expect(wrapper.html()).toBe(null)
+    expect(wrapper.html()).toBe('')
   })
 
   describe('', () => {

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -60,16 +60,23 @@ export function validateChangedFields(changedFields, address, rules) {
       )
 
       const isVisited = visitedFields.indexOf(fieldName) !== -1
+
       const becameValid =
         (!address[fieldName] || address[fieldName].valid !== true) &&
         validationResult.valid === true
+
+      const keptValid =
+        address[fieldName] &&
+        address[fieldName].valid === true &&
+        validationResult.valid === true
+
       const becameInvalid =
         address[fieldName] &&
         address[fieldName].valid === true &&
         validationResult.valid === false
 
       const showValidationResult =
-        isVisited || (!isVisited && (becameValid || becameInvalid))
+        isVisited || (!isVisited && (becameValid || becameInvalid || keptValid))
 
       resultAddress[fieldName] = {
         ...resultAddress[fieldName],

--- a/react/validateAddress.test.js
+++ b/react/validateAddress.test.js
@@ -392,6 +392,22 @@ describe('Address Validation:', () => {
     expect(result.postalCode.valid).toBeUndefined()
   })
 
+  it('should keep valid fields', () => {
+    const changedFieldsValid = {
+      postalCode: { value: '22231000' },
+    }
+
+    const validatedAddress = validateChangedFields(changedFieldsValid, address, usePostalCode)
+
+    const changedFieldsValid2 = {
+      postalCode: { value: '22231001' },
+    }
+
+    const result = validateChangedFields(changedFieldsValid2, validatedAddress, usePostalCode)
+
+    expect(result.postalCode.valid).toBe(true)
+  })
+
   it('should invalidate field when it was validated before being visited', () => {
     const changedFieldsValid = {
       postalCode: { value: '22231000' },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Validation changed from valid to undefined when a field changed between valid values.

#### What problem is this solving?

This error:
https://vtex.slack.com/archives/C9P4RMW6Q/p1564085997035900

#### How should this be manually tested?

Here:
https://vtexexito--prueba1.myvtex.com/televisor-led-super-uhd-4k-139-cms-55-pulgadas-smart-tv-664010/p

Also check the new unit test.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
