### PR TITLE
Fix Google Maps Chile rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `locality` in CHL to be in `neighborhood`
+
 ## [3.5.19] - 2019-07-26
 
 ### Fixed

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -515,6 +515,7 @@ export default {
     neighborhood: {
       valueIn: 'long_name',
       types: [
+        'locality',
         'neighborhood',
         'sublocality_level_1',
         'sublocality_level_2',
@@ -531,7 +532,7 @@ export default {
     },
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['administrative_area_level_2'],
       required: false,
     },
   },

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -515,6 +515,7 @@ export default {
     neighborhood: {
       valueIn: 'long_name',
       types: [
+        'administrative_area_level_3',
         'locality',
         'neighborhood',
         'sublocality_level_1',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Chile mapping was wrong. The neighborhood comes from "locality" or "administrative_area_level_3", which was mapped to city.

#### What problem is this solving?

Closes https://app.clubhouse.io/vtex/story/16932/regra-de-endere%C3%A7o-do-gmaps-para-o-chile-estava-errado-em-rela%C3%A7%C3%A3o-ao-bairro

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
