### PR TITLE
Remove checkout app dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Dependency from `vtex.checkout` since it's not needed.
+
 ## [3.5.20] - 2019-08-02
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,9 @@
   "defaultLocale": "en",
   "mustUpdateAt": "2019-01-08",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "settingsSchema": {},
   "dependencies": {
-    "vtex.checkout": "0.x",
     "vtex.country-codes": "1.x"
   },
   "builders": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Removed dependency from `vtex.checkout` since it's not needed.

#### What problem is this solving?
It's giving cyclic dependencies in some cases.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
