### PR TITLE
Fix Chile postal-code for Puerto Montt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Update Chile postal-code for Puerto Montt (Region X).
 
 ## [3.6.4] - 2019-09-24
 

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -330,7 +330,7 @@ const countryData = {
     Maullín: '5580000',
     Osorno: '5290000',
     Palena: '5880000',
-    'Puerto Montt': '5500000',
+    'Puerto Montt': '5480000',
     'Puerto Octay': '5370000',
     'Puerto Varas': '5550000',
     Puqueldón: '5760000',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix Chile postal-code for Puerto Montt (Region X) as requested via ticket [191258](https://vtexhelp.zendesk.com/agent/tickets/191258).

#### How should this be manually tested?

- add to cart: https://vtexgame1.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&redirect=true&sc=2
- fill the address fields with:
![image](https://user-images.githubusercontent.com/7749043/66049196-57aa0900-e501-11e9-9212-d22bd60aa88a.png)
- watch the postalCode sent in the "POST shippingData" request 
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
