### PR TITLE
Fixes missing validation message to GeolocationNumberInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.6.5] - 2019-10-03
 ### Fixed
+
+- Missing validation message to `GeolocationNumberInput`
+
+## [3.6.5] - 2019-10-03
+
+### Fixed
+
 - Update Chile postal-code for Puerto Montt (Region X).
 
 ## [3.6.4] - 2019-09-24
@@ -18,11 +24,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Spanish locale messages
 
 ## [3.6.3] - 2019-09-23
+
 ### Fixed
+
 - Removed unused depdendency (`regexpp`).
 
 ## [3.6.2] - 2019-09-23
+
 ### Changed
+
 - Removed eslint-utils from dependencies--moved to devDependencies.
 
 ## [3.6.1] - 2019-08-28

--- a/react/inputs/DefaultInput/GeolocationNumberInput.js
+++ b/react/inputs/DefaultInput/GeolocationNumberInput.js
@@ -8,6 +8,8 @@ import { injectIntl, intlShape } from 'react-intl'
 import InputText from './InputText'
 import InputLabel from './InputLabel'
 import InputCheckbox from './InputCheckbox'
+import InputError from './InputError'
+
 import cx from 'classnames'
 
 class GeolocationNumberInput extends Component {
@@ -32,6 +34,7 @@ class GeolocationNumberInput extends Component {
     })
 
     const value = address[field.name].value
+    const valid = address[field.name].valid
 
     return (
       <div className={className} htmlFor={`ship-${field.name}`}>
@@ -52,14 +55,19 @@ class GeolocationNumberInput extends Component {
             value={value}
             onFocus={onFocus}
           />
+          {valid === false ? (
+            <InputError reason={address[field.name].reason} />
+          ) : null}
         </InputLabel>
-        <InputLabel field={{name: 'checkboxNumberLabel', label: 'noNumber'}}>
+        <InputLabel field={{ name: 'checkboxNumberLabel', label: 'noNumber' }}>
           <InputCheckbox
             address={address}
             field={field}
-            placeholder={!field.hidden && !field.required
-              ? intl.formatMessage({ id: 'address-form.optional' })
-              : null}
+            placeholder={
+              !field.hidden && !field.required
+                ? intl.formatMessage({ id: 'address-form.optional' })
+                : null
+            }
             onFocus={onFocus}
             onBlur={onBlur}
             onChange={handleToggle}


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Fixed

- Missing validation message to GeolocationNumberInput

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/18562/campo-obrigat%C3%B3rio-n%C3%BAmero-sem-hint-tooltip-quando-endere%C3%A7o-%C3%A9-por-geolocation)

#### How should this be manually tested?
1. Add [items to cart](https://fernando--vtexgame1geo.myvtex.com/checkout/cart/add?&workspace=fernando&sku=298&qty=1&seller=1&sc=1)
2. Go to Shipping and type `Praia de botafogo` without the number
3. Select the first item of the list
4. Try to calculate shipping and it should show the required error below the number field.

#### Screenshots or example usage
n/a
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
