### PR TITLE
Add autoFocus to StyleguideInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `autoFocus` to `StyleguideInput`.
+
 ## [4.2.2] - 2019-09-20
 
 ## [4.2.1] - 2019-09-20

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -253,6 +253,7 @@ StyleguideInput.defaultProps = {
 
 StyleguideInput.propTypes = {
   address: PropTypes.object,
+  autoFocus: PropTypes.bool,
   Button: PropTypes.func,
   field: PropTypes.object.isRequired,
   inputRef: PropTypes.func,

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -44,6 +44,7 @@ class StyleguideInput extends Component {
   render() {
     const {
       address,
+      autoFocus,
       Button,
       field,
       options,
@@ -71,6 +72,7 @@ class StyleguideInput extends Component {
             label={this.props.intl.formatMessage({
               id: `address-form.field.${field.name}`,
             })}
+            autoFocus={autoFocus}
             value={address[field.name].value || ''}
             disabled={disabled}
             error={!this.state.isInputValid}
@@ -136,6 +138,7 @@ class StyleguideInput extends Component {
                 id: 'address-form.geolocation.example.UNI',
               }),
             })}
+            autoFocus={autoFocus}
             onChange={this.props.onChange}
             onBlur={this.props.onBlur}
             disabled={loading || disabled}
@@ -167,6 +170,7 @@ class StyleguideInput extends Component {
                   id: 'address-form.geolocation.example.UNI',
                 }),
               })}
+              autoFocus={autoFocus}
               onChange={this.props.onChange}
               onBlur={this.props.onBlur}
               disabled={loading || disabled}
@@ -233,6 +237,7 @@ class StyleguideInput extends Component {
               ? this.props.intl.formatMessage({ id: 'address-form.optional' })
               : null
           }
+          autoFocus={autoFocus}
           onBlur={this.props.onBlur}
           onChange={this.handleChange}
         />


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, this PR adds `autoFocus` prop to `StyleguideInput`.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

The lack of `autoFocus` prop on `StyleguideInput`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to https://ordershipping--vtexgame1.myvtex.com/cart
- Click on "Alterar"
- Check if the input is being focused.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/66759474-af882e80-ee76-11e9-9341-5f9a4a283e16.png)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
