### PR TITLE
Fix/postal code autocomplete on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Postal code autocompletion on paste.
+
 ## [3.6.10] - 2019-10-29
 
 ### Changed
+
 - Update Ecuador rules, including some parishes for Pichincha province.
 
 ## [3.6.9] - 2019-10-28
 
 ### Added
+
 - Add German translations.
 
 ## [3.6.8] - 2019-10-21
 
 ### Changed
+
 - Add address examples in geolocation mode for some countries
 
 ## [3.6.7] - 2019-10-17
 
 ### Fixed
+
 - Update Chile postal code for some regions.
 
 ## [3.6.6] - 2019-10-14

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -53,11 +53,15 @@ class AddressContainer extends Component {
       changedAddressFields.postalCode &&
       !changedAddressFields.postalCode.geolocationAutoCompleted
     ) {
-      const postalCodeIsNowValid =
-        address.postalCode.valid !== true &&
-        validatedAddress.postalCode.valid === true
+      const diffFromPrev =
+        address.postalCode.value !== validatedAddress.postalCode.value
+      const isValidPostalCode = validatedAddress.postalCode.valid === true
+      const shouldAutoComplete =
+        rules.postalCodeFrom === POSTAL_CODE &&
+        diffFromPrev &&
+        isValidPostalCode
 
-      if (rules.postalCodeFrom === POSTAL_CODE && postalCodeIsNowValid) {
+      if (shouldAutoComplete) {
         return onChangeAddress(
           postalCodeAutoCompleteAddress({
             cors,

--- a/react/AutoCompletedFields.test.js
+++ b/react/AutoCompletedFields.test.js
@@ -15,7 +15,7 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={jest.fn()}
       >
         {children}
-      </AutoCompletedFields>
+      </AutoCompletedFields>,
     )
   })
 
@@ -27,9 +27,9 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={jest.fn()}
       >
         {children}
-      </AutoCompletedFields>
+      </AutoCompletedFields>,
     )
-    expect(wrapper.html()).toBe('')
+    expect(wrapper.html()).toBe(null)
   })
 
   it('should display nothing if there are autocompleted fields with no value', () => {
@@ -47,9 +47,9 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={jest.fn()}
       >
         {children}
-      </AutoCompletedFields>
+      </AutoCompletedFields>,
     )
-    expect(wrapper.html()).toBe('')
+    expect(wrapper.html()).toBe(null)
   })
 
   describe('', () => {
@@ -73,7 +73,7 @@ describe('AutoCompletedFields', () => {
           onChangeAddress={onChangeAddress}
         >
           {children}
-        </AutoCompletedFields>
+        </AutoCompletedFields>,
       )
     })
 
@@ -104,12 +104,12 @@ describe('AutoCompletedFields', () => {
       expect(onChangeAddressArgument.state).toHaveProperty('value', state)
       expect(onChangeAddressArgument.state).toHaveProperty(
         'geolocationAutoCompleted',
-        undefined
+        undefined,
       )
       expect(onChangeAddressArgument.city).toHaveProperty('value', city)
       expect(onChangeAddressArgument.state).toHaveProperty(
         'postalCodeAutoCompleted',
-        undefined
+        undefined,
       )
     })
 
@@ -137,7 +137,7 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={onChangeAddress}
       >
         {children}
-      </AutoCompletedFields>
+      </AutoCompletedFields>,
     )
 
     const AddressSummary = wrapper.find('AddressSummary')
@@ -165,7 +165,7 @@ describe('AutoCompletedFields', () => {
         onChangeAddress={onChangeAddress}
       >
         {children}
-      </AutoCompletedFields>
+      </AutoCompletedFields>,
     )
 
     const AddressSummary = wrapper.find('AddressSummary')


### PR DESCRIPTION
#### What problem is this solving?

Fix copy-pasting a postal code onto the cep field not changing the current autocompleted address.

Related to: https://app.clubhouse.io/vtex/story/23813/ao-colar-o-zipcode-ele-nao-atualiza-no-myaccount

#### How should this be manually tested?

- Goto https://kiwi--recorrenciaqa.myvtex.com/account#/addresses/
- Create an address
- Type a valid postal code, wait for it to autocomplete the rest of the fields
- Paste another valid postal code over the previous one
- Autocompleted fields should be updated.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
