### PR TITLE
Fixes Peru neighborhood geolocation validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Peru neighborhood geolocation validation.
+
 ## [3.6.11] - 2019-10-31
 
 ### Fixed

--- a/react/country/PER.js
+++ b/react/country/PER.js
@@ -2434,9 +2434,9 @@ export default {
       required: false,
       handler: address => {
         if (
-          address.city &&
-          (address.city.value === 'Provincia de Lima' ||
-            address.city.value === 'Lima')
+          address.neighborhood &&
+          (address.neighborhood.value === 'Distrito de Lima' ||
+            address.neighborhood.value === 'Lima')
         ) {
           address.neighborhood = { value: 'Lima' }
           return address
@@ -2454,7 +2454,7 @@ export default {
           return address
         }
 
-        if (address.state && address.state.value === 'Distrito de Lima') {
+        if (address.state && address.state.value === 'Provincia de Lima') {
           address.state.value = 'Lima'
           return address
         }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fixes Peru neighborhood geolocation validation

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/25476/l%C3%B3gica-de-normaliza%C3%A7%C3%A3o-de-bairro-no-peru-%C3%A9-incorreta-no-v6)

Based on the configuration in https://github.com/vtex/front.shipping-data/blob/master/src/script/rule/CountryPER.coffee#L2432

#### How should this be manually tested?
1. Add [items to cart](https://fernando--wongfoodqacheckoutv6.myvtex.com/checkout/cart/add/?sku=14690&qty=1&seller=wongqa&sc=3&sku=905&qty=1&seller=1&sc=3

 Edit Description)
2. Go to Shipping
3. Type `Calle Augusto Angulo 130` and select first result
4. Neighbourhood should be `Miraflores` instead of `Lima`

#### Screenshots or example usage
n/a
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
