### PR TITLE
Adds external loading property for PostalCodeGetter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `StyleguideInput` to have an external loading property to show it in the right moment instead of
+  when autocomplete is performed
+
 ## [3.7.0] - 2019-11-18
 
 ### Fixed

--- a/react/InputFieldContainer.js
+++ b/react/InputFieldContainer.js
@@ -117,6 +117,7 @@ class InputFieldContainer extends Component {
     const {
       Input,
       Button,
+      loading,
       field,
       autoFocus,
       address,
@@ -147,6 +148,7 @@ class InputFieldContainer extends Component {
       <Input
         Button={Button}
         address={address}
+        loading={loading}
         field={field}
         autoFocus={autoFocus}
         options={_options}
@@ -165,11 +167,13 @@ class InputFieldContainer extends Component {
 InputFieldContainer.propTypes = {
   autoFocus: false,
   shouldShowNumberKeyboard: false,
+  loading: false,
 }
 
 InputFieldContainer.propTypes = {
   Button: PropTypes.func,
   Input: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
   autoFocus: PropTypes.bool,
   field: PropTypes.object.isRequired,
   address: AddressShapeWithValidation,

--- a/react/PostalCodeGetter.js
+++ b/react/PostalCodeGetter.js
@@ -18,6 +18,7 @@ class PostalCodeGetter extends Component {
     const {
       address,
       autoFocus,
+      loading,
       rules,
       onChangeAddress,
       Input,
@@ -33,6 +34,7 @@ class PostalCodeGetter extends Component {
         return (
           <ThreeLevels
             intl={intl}
+            loading={loading}
             Input={Input}
             Button={Button}
             address={address}
@@ -46,6 +48,7 @@ class PostalCodeGetter extends Component {
         return (
           <TwoLevels
             intl={intl}
+            loading={loading}
             Input={Input}
             Button={Button}
             address={address}
@@ -59,6 +62,7 @@ class PostalCodeGetter extends Component {
         return (
           <OneLevel
             intl={intl}
+            loading={loading}
             Input={Input}
             Button={Button}
             address={address}
@@ -74,6 +78,7 @@ class PostalCodeGetter extends Component {
         return (
           <InputFieldContainer
             intl={intl}
+            loading={loading}
             Input={Input}
             Button={Button}
             field={field}
@@ -93,6 +98,7 @@ class PostalCodeGetter extends Component {
 
 PostalCodeGetter.defaultProps = {
   autoFocus: false,
+  loading: false,
   Input: DefaultInput,
   shouldShowNumberKeyboard: false,
 }
@@ -100,6 +106,7 @@ PostalCodeGetter.defaultProps = {
 PostalCodeGetter.propTypes = {
   address: AddressShapeWithValidation,
   autoFocus: PropTypes.bool,
+  loading: PropTypes.bool,
   Input: PropTypes.func,
   Button: PropTypes.func,
   intl: intlShape.isRequired,
@@ -110,9 +117,5 @@ PostalCodeGetter.propTypes = {
   submitLabel: PropTypes.string,
 }
 
-const enhance = compose(
-  injectAddressContext,
-  injectRules,
-  injectIntl,
-)
+const enhance = compose(injectAddressContext, injectRules, injectIntl)
 export default enhance(PostalCodeGetter)

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -47,13 +47,12 @@ class StyleguideInput extends Component {
       Button,
       field,
       options,
-      onSubmit,
+      loading,
       inputRef,
       intl,
       toggleNotApplicable,
       submitLabel,
     } = this.props
-    const loading = !!address[field.name].loading
     const disabled = !!address[field.name].disabled
 
     const inputCommonProps = {
@@ -239,6 +238,7 @@ StyleguideInput.defaultProps = {
 StyleguideInput.propTypes = {
   address: PropTypes.object,
   autoFocus: PropTypes.bool,
+  loading: PropTypes.bool,
   Button: PropTypes.func,
   field: PropTypes.object.isRequired,
   inputRef: PropTypes.func,

--- a/react/postalCodeFrom/OneLevel.js
+++ b/react/postalCodeFrom/OneLevel.js
@@ -15,6 +15,7 @@ class OneLevel extends Component {
       address,
       Button,
       Input,
+      loading,
       onSubmit,
       onChangeAddress,
       rules,
@@ -30,6 +31,7 @@ class OneLevel extends Component {
           <SelectPostalCode
             address={address}
             Input={Input}
+            loading={loading}
             rules={rules}
             onChangeAddress={onChangeAddress}
           />
@@ -42,6 +44,7 @@ class OneLevel extends Component {
         <SelectPostalCode
           address={address}
           Input={Input}
+          loading={loading}
           rules={rules}
           onChangeAddress={onChangeAddress}
         />
@@ -53,6 +56,7 @@ class OneLevel extends Component {
 OneLevel.propTypes = {
   address: AddressShapeWithValidation,
   Button: PropTypes.func,
+  loading: PropTypes.bool,
   Input: PropTypes.func.isRequired,
   rules: PropTypes.object.isRequired,
   onChangeAddress: PropTypes.func.isRequired,

--- a/react/postalCodeFrom/SelectPostalCode.js
+++ b/react/postalCodeFrom/SelectPostalCode.js
@@ -48,7 +48,7 @@ class SelectPostalCode extends Component {
   }
 
   render() {
-    const { address, rules, Input, intl } = this.props
+    const { address, rules, Input, loading, intl } = this.props
     const currentLevelField = getLastLevelField(rules)
     const fieldName = currentLevelField.name
 
@@ -64,6 +64,7 @@ class SelectPostalCode extends Component {
       <InputFieldContainer
         intl={intl}
         Input={Input}
+        loading={loading}
         field={currentLevelField}
         address={newAddress}
         options={this.getOptions(fieldName, address, rules)}
@@ -77,6 +78,7 @@ class SelectPostalCode extends Component {
 SelectPostalCode.propTypes = {
   Input: PropTypes.func.isRequired,
   intl: intlShape,
+  loading: PropTypes.bool,
   address: AddressShapeWithValidation.isRequired,
   rules: PropTypes.object.isRequired,
   onChangeAddress: PropTypes.func.isRequired,

--- a/react/postalCodeFrom/ThreeLevels.js
+++ b/react/postalCodeFrom/ThreeLevels.js
@@ -17,6 +17,7 @@ class ThreeLevels extends Component {
       Button,
       rules,
       Input,
+      loading,
       onChangeAddress,
       onSubmit,
       submitLabel,
@@ -31,6 +32,7 @@ class ThreeLevels extends Component {
           <SelectLevel
             level={0}
             Input={Input}
+            loading={loading}
             rules={rules}
             address={address}
             onChangeAddress={onChangeAddress}
@@ -38,12 +40,14 @@ class ThreeLevels extends Component {
           <SelectLevel
             level={1}
             Input={Input}
+            loading={loading}
             rules={rules}
             address={address}
             onChangeAddress={onChangeAddress}
           />
           <SelectPostalCode
             Input={Input}
+            loading={loading}
             rules={rules}
             address={address}
             onChangeAddress={onChangeAddress}
@@ -58,6 +62,7 @@ class ThreeLevels extends Component {
         <SelectLevel
           level={0}
           Input={Input}
+          loading={loading}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
@@ -65,12 +70,14 @@ class ThreeLevels extends Component {
         <SelectLevel
           level={1}
           Input={Input}
+          loading={loading}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
         />
         <SelectPostalCode
           Input={Input}
+          loading={loading}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
@@ -83,6 +90,7 @@ class ThreeLevels extends Component {
 ThreeLevels.propTypes = {
   address: AddressShapeWithValidation,
   Button: PropTypes.func,
+  loading: PropTypes.func,
   Input: PropTypes.func.isRequired,
   onChangeAddress: PropTypes.func.isRequired,
   onSubmit: PropTypes.func,

--- a/react/postalCodeFrom/TwoLevels.js
+++ b/react/postalCodeFrom/TwoLevels.js
@@ -16,6 +16,7 @@ class TwoLevels extends Component {
       address,
       rules,
       Input,
+      loading,
       onChangeAddress,
       onSubmit,
       submitLabel,
@@ -31,12 +32,14 @@ class TwoLevels extends Component {
           <SelectLevel
             level={0}
             Input={Input}
+            loading={loading}
             rules={rules}
             address={address}
             onChangeAddress={onChangeAddress}
           />
           <SelectPostalCode
             Input={Input}
+            loading={loading}
             rules={rules}
             address={address}
             onChangeAddress={onChangeAddress}
@@ -51,12 +54,14 @@ class TwoLevels extends Component {
         <SelectLevel
           level={0}
           Input={Input}
+          loading={loading}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
         />
         <SelectPostalCode
           Input={Input}
+          loading={loading}
           rules={rules}
           address={address}
           onChangeAddress={onChangeAddress}
@@ -69,6 +74,7 @@ class TwoLevels extends Component {
 TwoLevels.propTypes = {
   address: AddressShapeWithValidation,
   Button: PropTypes.func,
+  loading: PropTypes.bool,
   Input: PropTypes.func.isRequired,
   onChangeAddress: PropTypes.func.isRequired,
   onSubmit: PropTypes.func,

--- a/react/pureInputField.js
+++ b/react/pureInputField.js
@@ -5,6 +5,7 @@ import AddressShapeWithValidation from './propTypes/AddressShapeWithValidation'
 const SHALLOW_PROPS = [
   'Input',
   'autoFocus',
+  'loading',
   'field',
   'rules',
   'options',
@@ -70,12 +71,14 @@ function pureInputField(WrappedComponent) {
 
   PureInput.propTypes = {
     autoFocus: false,
+    loading: false,
     shouldShowNumberKeyboard: false,
   }
 
   PureInput.propTypes = {
     Input: PropTypes.func.isRequired,
     autoFocus: PropTypes.bool,
+    loading: PropTypes.bool,
     field: PropTypes.object.isRequired,
     address: AddressShapeWithValidation,
     rules: PropTypes.object.isRequired,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds external loading property for PostalCodeGetter

#### What problem is this solving?
Before, loading was set when an address was being auto completed which often is a bad thing because it prevents the user from editing the address.

#### How should this be manually tested?
1. Add [items to cart](https://fernando--checkoutio.myvtex.com/cart/add?&workspace=fernando&sku=298&qty=1&seller=1&sc=1);
2. Estimate shipping in the cart;

#### Screenshots or example usage
n/a
#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
