### PR TITLE
Fixes autocompleting address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Autocompleting address with a new address instead of just autocompleted fields which caused confusion
+  merging different addresses
+
 ## [3.8.2] - 2019-11-26
 
 ### Fixed

--- a/react/postalCodeAutoCompleteAddress.js
+++ b/react/postalCodeAutoCompleteAddress.js
@@ -6,6 +6,7 @@ import {
   handleMultipleValues,
   maskFields,
   addFocusToNextInvalidField,
+  newAddress,
 } from './transforms/address'
 import flow from 'lodash/flow'
 import pickBy from 'lodash/pickBy'
@@ -41,7 +42,9 @@ export default function postalCodeAutoCompleteAddress({
 
       const autoCompletedFields = flow(functionsFlow)(responseAddress)
 
-      callback(autoCompletedFields)
+      const newAddressWithAutocompletedFields = newAddress(autoCompletedFields)
+
+      callback(newAddressWithAutocompletedFields)
     })
     .catch(() => {
       let newFields = removePostalCodeLoading(address)

--- a/react/transforms/address.js
+++ b/react/transforms/address.js
@@ -209,3 +209,45 @@ function getFirstRequiredFieldNotFilled(fields, rules) {
 
   return null
 }
+
+let gguid = 1
+
+export default function getGGUID() {
+  return (gguid++ * new Date().getTime() * -1).toString().replace('-', '')
+}
+
+export function newAddress(address = {}) {
+  const {
+    addressType,
+    city,
+    complement,
+    country,
+    geoCoordinates,
+    neighborhood,
+    number,
+    postalCode,
+    receiverName,
+    reference,
+    state,
+    street,
+    addressQuery,
+    addressId,
+  } = address
+
+  return {
+    addressId: addressId || { value: getGGUID() },
+    addressType: addressType || { value: 'residential' },
+    city: city || { value: null },
+    complement: complement || { value: null },
+    country: country || { value: null },
+    geoCoordinates: geoCoordinates || { value: [] },
+    neighborhood: neighborhood || { value: null },
+    number: number || { value: null },
+    postalCode: postalCode || { value: null },
+    receiverName: receiverName || { value: null },
+    reference: reference || { value: null },
+    state: state || { value: null },
+    street: street || { value: null },
+    addressQuery: addressQuery || { value: '' },
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes autocompleting address with new address instead of merging with old address

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/26638/criar-solu%C3%A7%C3%A3o-de-contorno-para-mudan%C3%A7a-de-cep-que-n%C3%A3o-limpa-campos-n%C3%BAmero-de-complemento)

#### How should this be manually tested?
1. Add [items to cart](https://autocomplete--vtexgame1.myvtex.com/checkout/cart/add?&workspace=autocomplete&sku=298&qty=1&seller=1&sc=1)
2. Go to shipping
3. Fill postal code `22071060`
4. Fill the number and complement fields
5. Retyping postal code should reset address number and complement

#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
