### PR TITLE
Fixes Postal Code autocomplete which should only call API if country is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Postal Code autocomplete which should only call API if country is supported
+
 ## [3.8.3] - 2019-11-27
 
 ### Fixed

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -53,13 +53,17 @@ class AddressContainer extends Component {
       changedAddressFields.postalCode &&
       !changedAddressFields.postalCode.geolocationAutoCompleted
     ) {
+      const postalCodeField = rules.fields.find(
+        field => field.name === 'postalCode',
+      )
       const diffFromPrev =
         address.postalCode.value !== validatedAddress.postalCode.value
       const isValidPostalCode = validatedAddress.postalCode.valid === true
       const shouldAutoComplete =
         rules.postalCodeFrom === POSTAL_CODE &&
         diffFromPrev &&
-        isValidPostalCode
+        isValidPostalCode &&
+        postalCodeField.postalCodeAPI
 
       if (shouldAutoComplete) {
         return onChangeAddress(

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -18,6 +18,7 @@ export default {
       label: 'postalCode',
       size: 'small',
       autoComplete: 'nope',
+      postalCodeAPI: false,
     },
     {
       name: 'street',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes Postal Code autocomplete which should only call API if country is supported

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/26964/regress%C3%A3o-inser%C3%A7%C3%A3o-do-postalcode-em-pa%C3%ADses-n%C3%A3o-mapeados)

#### How should this be manually tested?
1. Add [items to cart](https://autocompleteapi--vtexgame1.myvtex.com/checkout/cart/add?&workspace=fernando&sku=312&qty=1&seller=1&sc=2)
2. Change country to Bulgaria (or other unmapped country)
3. Type a random postal code
4. At every type it should not make requests to Autocomplete API

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
