### PR TITLE
Fix spinner breaking the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Spinner` breaking the UI because of `undefined` prop being rendered.
+
 ## [3.8.1] - 2019-11-26
 
 ### Fixed

--- a/react/Spinner.js
+++ b/react/Spinner.js
@@ -7,7 +7,7 @@ class SpinnerLoading extends Component {
     const { isLoading } = this.props
 
     return (
-      isLoading && (
+      isLoading === true && (
         <div className="pl1 pt7">
           <Spinner size={15} />
         </div>

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -47,13 +47,14 @@ class StyleguideInput extends Component {
       Button,
       field,
       options,
-      loading,
+      loading: loadingProp,
       inputRef,
       intl,
       toggleNotApplicable,
       submitLabel,
     } = this.props
     const disabled = !!address[field.name].disabled
+    const loading = loadingProp || !!address[field.name].loading
 
     const inputCommonProps = {
       label: this.props.intl.formatMessage({


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix a breaking UI.

#### What problem is this solving?

One of the changes of #219 made possible to return `undefined` from the render method of the `Spinner` component and Mr. React wasn't liking that.

#### How should this be manually tested?

1) https://kiwi--recorrenciaqa.myvtex.com/account#/addresses/new
2) See if the page loads

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
