### PR TITLE
Fixes loading for scenarios when loading is passed as a prop to `StyleguideInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Loading for scenarios when loading is passed as a prop to `StyleguideInput`.
+
 ## [3.8.4] - 2019-11-27
 
 ### Fixed
 
-- Postal Code autocomplete which should only call API if country is supported
+- Postal Code autocomplete which should only call API if country is supported.
 
 ## [3.8.3] - 2019-11-27
 
 ### Fixed
 
 - Autocompleting address with a new address instead of just autocompleted fields which caused confusion
-  merging different addresses
+  merging different addresses.
 
 ## [3.8.2] - 2019-11-26
 

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -54,7 +54,9 @@ class StyleguideInput extends Component {
       submitLabel,
     } = this.props
     const disabled = !!address[field.name].disabled
-    const loading = loadingProp || !!address[field.name].loading
+
+    const loading =
+      loadingProp != null ? loadingProp : address[field.name].loading
 
     const inputCommonProps = {
       label: this.props.intl.formatMessage({


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fixes loading for scenarios when loading is passed as a prop to `StyleguideInput`
#### What problem is this solving?
- Inputing postal code was giving the wrong behavior.
#### How should this be manually tested?
1. Add [items to cart](https://fernando--checkoutio.myvtex.com/cart/add?&workspace=fernando&sku=298&qty=1&seller=1&sc=1)
2. Type `22071060` postal code to simulate shipping
3. It should not set loading before clicking calculate.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
