### PR TITLE
Fix/state selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- State/city selection on Chile because postalCode was not required when it should
+- Flaky tests that would return empty string or null depending of computer/Node version
+
 ## [3.8.5] - 2019-12-10
 
 ### Fixed

--- a/react/AutoCompletedFields.test.js
+++ b/react/AutoCompletedFields.test.js
@@ -29,7 +29,7 @@ describe('AutoCompletedFields', () => {
         {children}
       </AutoCompletedFields>,
     )
-    expect(wrapper.html()).toBe('')
+    expect(wrapper.html()).toBeFalsy()
   })
 
   it('should display nothing if there are autocompleted fields with no value', () => {
@@ -49,7 +49,7 @@ describe('AutoCompletedFields', () => {
         {children}
       </AutoCompletedFields>,
     )
-    expect(wrapper.html()).toBe('')
+    expect(wrapper.html()).toBeFalsy()
   })
 
   describe('', () => {

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -436,6 +436,7 @@ export default {
       postalCodeAPI: false,
       regex: /^([\d]{7})$/,
       size: 'large',
+      required: true,
     },
     {
       name: 'street',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix shipping step for Chile that wasn't able to change region (state) after community (city) selection.
https://app.clubhouse.io/vtex/story/27751/problema-com-sele%C3%A7%C3%A3o-de-state-city-para-chile

Also fix flaky test that was returning empty string or null depending on computer/Node version.

#### How should this be manually tested?

1. https://darlene--vtexgame1.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
2. Select Chile
3. Select any region (state)
4. Select any community (city)
5. Change region (state) and it should empty community (city) field

#### Screenshots or example usage

*BEFORE*
![bad](https://user-images.githubusercontent.com/850280/70571954-93a2bf80-1b7d-11ea-9254-012ee2e37ebd.gif)

*AFTER*
![good](https://user-images.githubusercontent.com/850280/70571974-9f8e8180-1b7d-11ea-8e89-bd471dc94331.gif)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
