### PR TITLE
Input field now uses a given country's postal code mask to decide whether …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Input field now uses `shouldShowNumberKeyboard` prop.
+- Input field now uses `shouldShowNumberKeyboard` prop which, in turn, uses a country's postal code mask to decide its value.
 
 ## [4.3.5] - 2019-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Input field now uses `shouldShowNumberKeyboard` prop.
+
 ## [4.3.5] - 2019-12-16
 
 ### Changed

--- a/react/PostalCodeGetter.js
+++ b/react/PostalCodeGetter.js
@@ -12,6 +12,7 @@ import { injectRules } from './addressRulesContext'
 import { compose } from 'recompose'
 import { injectAddressContext } from './addressContainerContext'
 import { injectIntl, intlShape } from 'react-intl'
+import { removeNonWords } from './transforms/utils'
 
 class PostalCodeGetter extends Component {
   render() {
@@ -26,7 +27,6 @@ class PostalCodeGetter extends Component {
       intl,
       onSubmit,
       submitLabel,
-      shouldShowNumberKeyboard,
     } = this.props
 
     switch (rules.postalCodeFrom) {
@@ -75,6 +75,7 @@ class PostalCodeGetter extends Component {
       default:
       case POSTAL_CODE: {
         const field = getField('postalCode', rules)
+        const shouldShowNumberKeyboard = !isNaN(removeNonWords(field.mask))
         return (
           <InputFieldContainer
             intl={intl}

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -63,12 +63,14 @@ class StyleguideInput extends Component {
       inputRef,
       intl,
       toggleNotApplicable,
+      shouldShowNumberKeyboard,
       submitLabel,
     } = this.props
     const disabled = !!address[field.name].disabled
 
     const loading =
       loadingProp != null ? loadingProp : address[field.name].loading
+    const type = shouldShowNumberKeyboard ? 'tel' : 'text'
 
     const inputCommonProps = {
       label: this.props.intl.formatMessage({
@@ -89,6 +91,7 @@ class StyleguideInput extends Component {
       onChange: this.handleChange,
       onFocus: this.handleFocus,
       isLoading: loading,
+      type,
     }
 
     if (field.name === 'postalCode') {
@@ -133,7 +136,8 @@ class StyleguideInput extends Component {
               intl.formatMessage({ id: `address-form.field.${field.label}` })
             }
             errorMessage={
-              address[field.name].reason && this.state.showErrorMessage &&
+              address[field.name].reason &&
+              this.state.showErrorMessage &&
               this.props.intl.formatMessage({
                 id: `address-form.error.${address[field.name].reason}`,
               })
@@ -170,7 +174,8 @@ class StyleguideInput extends Component {
                 intl.formatMessage({ id: `address-form.field.${field.label}` })
               }
               errorMessage={
-                address[field.name].reason && this.showErrorMessage &&
+                address[field.name].reason &&
+                this.showErrorMessage &&
                 this.props.intl.formatMessage({
                   id: `address-form.error.${address[field.name].reason}`,
                 })

--- a/react/transforms/utils.js
+++ b/react/transforms/utils.js
@@ -1,0 +1,3 @@
+export function removeNonWords(string) {
+  return string.replace(/\W/, '')
+}

--- a/react/transforms/utils.js
+++ b/react/transforms/utils.js
@@ -1,3 +1,3 @@
 export function removeNonWords(string) {
-  return string.replace(/\W/, '')
+  return string.replace(/\W/g, '')
 }


### PR DESCRIPTION
…it should show the numeric keyboard or not

#### What is the purpose of this pull request?

 As the title says, this PR adds the use of a given postal code mask to decide whether it should show the numeric keyboard or not. 

<!--- Describe your changes in detail. -->

#### What problem is this solving?

We need to show a proper input field for the user to type a postal code.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Grab a mobile device
- Proceed to the [workspace](https://numerickeyboard--checkoutio.myvtex.com/cart/add?sku=288)
- Try to type a postal code
- Verify that now a numeric keyboard is presented instead of the text one.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/71120246-befb5f00-21ba-11ea-8b4d-cb0d7316b736.png)


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
