### PR TITLE
Fix when a given country's postal code mask is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `undefined` postal code mask causing `address-form` to break.
 
 ## [4.4.0] - 2020-01-02
 

--- a/demo/src/Container.js
+++ b/demo/src/Container.js
@@ -26,6 +26,7 @@ const shipsTo = [
   'URY',
   'USA',
   'VEN',
+  'ITA',
 ]
 
 class Container extends Component {

--- a/react/transforms/utils.js
+++ b/react/transforms/utils.js
@@ -1,3 +1,3 @@
 export function removeNonWords(string) {
-  return string.replace(/\W/g, '')
+  return string && string.replace(/\W/g, '')
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds a fix to when a given country's postal code mask is `undefined`.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

This prevents the `address-form` to break when the scenario above happens.

<!--- What is the motivation and context for this change? -->

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
