### PR TITLE
Fix geolocation autocomplete in URY countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Number geolocation autofill in URY addresses.
+
 ## [3.8.11] - 2020-02-14
 
 ### Fixed

--- a/react/country/URY.js
+++ b/react/country/URY.js
@@ -427,9 +427,10 @@ export default {
       types: ['postal_code'],
       required: false,
     },
-    complement: {
+    number: {
       valueIn: 'long_name',
       types: ['street_number'],
+      notApplicable: true,
     },
     street: { valueIn: 'long_name', types: ['route'] },
     neighborhood: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the autocomplete of the number field in URY contries with geolocation.

#### What problem is this solving?
Fixes [this story](https://app.clubhouse.io/vtex/story/28596/loja-do-uruguai-n%C3%A3o-consegue-utilizar-checkout-v6-com-geolocation).

#### How should this be manually tested?
[Workspace](https://lucas--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&redirect=true&sc=2)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
