### PR TITLE
Change default geolocation setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Default geolocation setup.
+
 ## [3.9.0] - 2020-03-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Default geolocation setup.
+- Default number geolocation setup.
 
 ## [3.9.0] - 2020-03-10
 

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -83,10 +83,10 @@ export default {
       types: ['postal_code'],
       required: false,
     },
-    complement: {
+    number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
     street: { valueIn: 'long_name', types: ['route'] },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix some of the problems mentioned [here](https://app.clubhouse.io/vtex/story/27942/loja-do-panam%C3%A1-n%C3%A3o-consegue-utilizar-checkout-v6-com-geolocation). 

#### What problem is this solving?
Some addresses like `3 doris st north sydney` could not allow the user to go through the shipping step since the complement for default countries was required and that none is being returned by the Google api in this case. 

That said, user was presented a calculate shipping button doing nothing since it verifies the presence of the address number in order to do the calculation. 

This PR does not fix 100% of the problem but some of it. Another PR will come after more testing.

#### How should this be manually tested?
Load https://vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&redirect=true&sc=2 and use the following address:
`3 doris st north sydney`

Do the same in this workspace with the linked solution: https://kevin--vtexgame1geo.myvtex.com/checkout/#/shipping

#### Screenshots or example usage
Before:
![Screen Shot 2020-04-03 at 10 09 45](https://user-images.githubusercontent.com/2573602/78364201-72823680-7593-11ea-828c-31bd7215b22e.png)

After:
![Screen Shot 2020-04-03 at 10 09 51](https://user-images.githubusercontent.com/2573602/78364329-a8bfb600-7593-11ea-9f64-c78777aba57e.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
