### PR TITLE
Fix `import` line in top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ npm install @vtex/address-form
 ```
 
 ```js
-import AddressContainer from '@vtex/address-form/AddressContainer'
+import AddressContainer from '@vtex/address-form/lib/AddressContainer'
 ```
 
 Through **vtex.io**:


### PR DESCRIPTION
The previous version omitted the `/lib/` component of the import path, without which the import fails, saying
> Module not found: Error: Can't resolve '@vtex/address-form/AddressContainer'
