### PR TITLE
Update geolocationAutoCompleted verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `geolocationAutoCompleted` verification in `handleAddressChange()` to display number input when not written down in geolocation field.
+
 ## [3.10.1] - 2020-05-11
 
 ### Fixed

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -32,7 +32,7 @@ class AddressContainer extends Component {
     }
   }
 
-  handleAddressChange = changedAddressFields => {
+  handleAddressChange = (changedAddressFields) => {
     const {
       cors,
       accountName,
@@ -64,10 +64,10 @@ class AddressContainer extends Component {
     if (
       autoCompletePostalCode &&
       changedAddressFields.postalCode &&
-      !changedAddressFields.postalCode.geolocationAutoCompleted
+      changedAddressFields.postalCode.geolocationAutoCompleted === false
     ) {
       const postalCodeField = rules.fields.find(
-        field => field.name === 'postalCode',
+        (field) => field.name === 'postalCode',
       )
       const diffFromPrev =
         address.postalCode.value !== validatedAddress.postalCode.value

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -64,11 +64,11 @@ class AddressContainer extends Component {
     if (
       autoCompletePostalCode &&
       changedAddressFields.postalCode &&
-      changedAddressFields.postalCode.geolocationAutoCompleted === false
+      !changedAddressFields.postalCode.geolocationAutoCompleted
     ) {
-      const postalCodeField = rules.fields.find(
-        (field) => field.name === 'postalCode',
-      )
+      const postalCodeField =
+        rules.fields &&
+        rules.fields.find((field) => field.name === 'postalCode')
       const diffFromPrev =
         address.postalCode.value !== validatedAddress.postalCode.value
       const isValidPostalCode = validatedAddress.postalCode.valid === true
@@ -76,6 +76,7 @@ class AddressContainer extends Component {
         rules.postalCodeFrom === POSTAL_CODE &&
         diffFromPrev &&
         isValidPostalCode &&
+        postalCodeField &&
         postalCodeField.postalCodeAPI
 
       if (shouldAutoComplete) {

--- a/react/AddressContainer.test.js
+++ b/react/AddressContainer.test.js
@@ -8,12 +8,8 @@ import { mount, render } from 'test-utils'
 
 jest.mock('./postalCodeAutoCompleteAddress')
 
-const descendToChild = wrapper =>
-  wrapper
-    .children()
-    .children()
-    .children()
-    .children()
+const descendToChild = (wrapper) =>
+  wrapper.children().children().children().children()
 
 describe('AddressContainer', () => {
   const accountName = 'qamarketplace'
@@ -100,7 +96,10 @@ describe('AddressContainer', () => {
 
   it('should call onChangeAddress when postal code changes if shouldHandleAddressChangeOnMount is true', () => {
     const handleAddressChange = jest.fn()
-    const addressWithPostalCode = { ...address, postalCode: { value: '22250-040' } }
+    const addressWithPostalCode = {
+      ...address,
+      postalCode: { value: '22250-040' },
+    }
 
     const wrapper = mount(
       <AddressContainer
@@ -142,7 +141,12 @@ describe('AddressContainer', () => {
 
       // Act
       const onChangeAddress = descendToChild(wrapper).props().onChangeAddress
-      onChangeAddress({ postalCode: { value: '22231000' } })
+      onChangeAddress({
+        postalCode: {
+          value: '22231000',
+          geolocationAutoCompleted: false,
+        },
+      })
 
       // Assert
       expect(postalCodeAutoCompleteAddress).toHaveBeenCalled()

--- a/react/AddressContainer.test.js
+++ b/react/AddressContainer.test.js
@@ -141,12 +141,7 @@ describe('AddressContainer', () => {
 
       // Act
       const onChangeAddress = descendToChild(wrapper).props().onChangeAddress
-      onChangeAddress({
-        postalCode: {
-          value: '22231000',
-          geolocationAutoCompleted: false,
-        },
-      })
+      onChangeAddress({ postalCode: { value: '22231000' } })
 
       // Assert
       expect(postalCodeAutoCompleteAddress).toHaveBeenCalled()


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the `geolocationAutoCompleted` verification in `AddressContainer`.

#### What problem is this solving?
Number input was not being displayed when not written down on the previous step (geolocation search).

#### How should this be manually tested?
https://kevin--vtexgame1geo.myvtex.com/checkout/#/shipping

#### Related
https://app.clubhouse.io/vtex/story/27942/loja-do-panam%C3%A1-n%C3%A3o-consegue-utilizar-checkout-v6-com-geolocation

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
