### PR TITLE
Fix autocomplete removing other fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Autocomplete was removing other fields values when the request was finished.
+
 ## [3.10.0] - 2020-05-04
 
 ### Added

--- a/react/postalCodeAutoCompleteAddress.js
+++ b/react/postalCodeAutoCompleteAddress.js
@@ -26,23 +26,26 @@ export default function postalCodeAutoCompleteAddress({
     country: address.country.value,
     postalCode: address.postalCode.value,
   })
-    .then(responseAddress => {
+    .then((responseAddress) => {
       const functionsFlow = [
-        fields => pickBy(fields, field => !isNil(field) && field !== ''),
-        fields => addValidation(fields, address),
-        fields => handleMultipleValues(fields),
-        fields => maskFields(fields, rules),
-        fields => addNewField(fields, 'postalCodeAutoCompleted', true),
-        fields => addDisabledToProtectedFields(fields, rules),
+        (fields) => pickBy(fields, (field) => !isNil(field) && field !== ''),
+        (fields) => addValidation(fields, address),
+        (fields) => handleMultipleValues(fields),
+        (fields) => maskFields(fields, rules),
+        (fields) => addNewField(fields, 'postalCodeAutoCompleted', true),
+        (fields) => addDisabledToProtectedFields(fields, rules),
         removePostalCodeLoading,
         ...(shouldAddFocusToNextInvalidField
-          ? [fields => addFocusToNextInvalidField(fields, rules)]
+          ? [(fields) => addFocusToNextInvalidField(fields, rules)]
           : []),
       ]
 
       const autoCompletedFields = flow(functionsFlow)(responseAddress)
 
-      const newAddressWithAutocompletedFields = newAddress(autoCompletedFields)
+      const newAddressWithAutocompletedFields = newAddress({
+        ...address,
+        ...autoCompletedFields,
+      })
 
       callback(newAddressWithAutocompletedFields)
     })
@@ -52,7 +55,7 @@ export default function postalCodeAutoCompleteAddress({
       callback(newFields)
     })
     .catch(
-      /* istanbul ignore next */ error => {
+      /* istanbul ignore next */ (error) => {
         // If the Jest test case that tests the catch() above fails,
         // the promise will catch the error and go to this branch
         // of the code. This console error makes the Jest error visible.


### PR DESCRIPTION
#### What is the purpose of this pull request?

- ditto.

#### What problem is this solving?

- Autocomplete was deleting the previously passed props when the request was finished.

#### How should this be manually tested?

- login in: https://storev1--recorrenciaqa.myvtex.com/account
- try to add a new address, you will see that the `Destinatário` field will be already filled.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
