### PR TITLE
Fix errorMessage prop of Styleguide's Input (4.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prop errorMessage of Styleguide's Input.
+
 ## [4.6.2] - 2020-06-17
 
 ### Changed

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -21,7 +21,7 @@ class StyleguideInput extends Component {
     }
   }
 
-  handleChange = e => {
+  handleChange = (e) => {
     this.setState({ showErrorMessage: false })
     this.props.onChange && this.props.onChange(e.target.value)
   }
@@ -37,17 +37,17 @@ class StyleguideInput extends Component {
     }
   }
 
-  handleFocus = event => {
+  handleFocus = (event) => {
     this.setState({ showErrorMessage: false })
   }
 
-  handleSubmit = event => {
+  handleSubmit = (event) => {
     event.preventDefault()
     this.setState({ showErrorMessage: true })
     this.props.onSubmit && this.props.onSubmit()
   }
 
-  handleBlur = event => {
+  handleBlur = (event) => {
     this.setState({ showErrorMessage: true })
     this.props.onBlur && this.props.onBlur(event)
   }
@@ -82,11 +82,11 @@ class StyleguideInput extends Component {
       error: !this.state.isInputValid,
       ref: inputRef,
       errorMessage:
-        this.state.showErrorMessage &&
-        address[field.name].reason &&
-        this.props.intl.formatMessage({
-          id: `address-form.error.${address[field.name].reason}`,
-        }),
+        this.state.showErrorMessage && address[field.name].reason
+          ? this.props.intl.formatMessage({
+              id: `address-form.error.${address[field.name].reason}`,
+            })
+          : undefined,
       onBlur: this.handleBlur,
       onChange: this.handleChange,
       onFocus: this.handleFocus,
@@ -136,11 +136,11 @@ class StyleguideInput extends Component {
               intl.formatMessage({ id: `address-form.field.${field.label}` })
             }
             errorMessage={
-              address[field.name].reason &&
-              this.state.showErrorMessage &&
-              this.props.intl.formatMessage({
-                id: `address-form.error.${address[field.name].reason}`,
-              })
+              address[field.name].reason && this.state.showErrorMessage
+                ? this.props.intl.formatMessage({
+                    id: `address-form.error.${address[field.name].reason}`,
+                  })
+                : undefined
             }
             placeholder={intl.formatMessage({
               id: `address-form.geolocation.example.${address.country.value}`,
@@ -174,11 +174,11 @@ class StyleguideInput extends Component {
                 intl.formatMessage({ id: `address-form.field.${field.label}` })
               }
               errorMessage={
-                address[field.name].reason &&
-                this.showErrorMessage &&
-                this.props.intl.formatMessage({
-                  id: `address-form.error.${address[field.name].reason}`,
-                })
+                address[field.name].reason && this.showErrorMessage
+                  ? this.props.intl.formatMessage({
+                      id: `address-form.error.${address[field.name].reason}`,
+                    })
+                  : undefined
               }
               placeholder={intl.formatMessage({
                 id: `address-form.geolocation.example.${address.country.value}`,
@@ -239,10 +239,11 @@ class StyleguideInput extends Component {
             id: `address-form.field.${field.label}`,
           })}
           errorMessage={
-            address[field.name].reason &&
-            intl.formatMessage({
-              id: `address-form.error.${address[field.name].reason}`,
-            })
+            address[field.name].reason
+              ? intl.formatMessage({
+                  id: `address-form.error.${address[field.name].reason}`,
+                })
+              : undefined
           }
           value={address[field.name].value || ''}
           disabled={disabled}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix this error:
![image](https://user-images.githubusercontent.com/284515/86962731-c0ca4700-c139-11ea-857f-2165748cc197.png)


Same fix on major 3.x: https://github.com/vtex/address-form/pull/270

#### What problem is this solving?

Remove console errors

#### How should this be manually tested?

Check the console of the fixed workspace:
https://breno--storecomponents.myvtex.com/wood-clock/p

Compare it with a workspace without the fix:
https://brenoswon--storecomponents.myvtex.com/wood-clock/p

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
