### PR TITLE
CHK-128: Fix autocomplete of an address with null country code

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -3,7 +3,6 @@
 .gitignore
 package.json
 README.md
-CHANGELOG.md
 node_modules/
 react/node_modules
 react/coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `handleAddressChange` calling `postalCodeAutoCompleteAddress` even with a `null` country code.
+
 ## [3.12.6] - 2020-08-03
 
 ### Added

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -32,7 +32,7 @@ class AddressContainer extends Component {
     }
   }
 
-  handleAddressChange = (changedAddressFields) => {
+  handleAddressChange = changedAddressFields => {
     const {
       cors,
       accountName,
@@ -67,15 +67,16 @@ class AddressContainer extends Component {
       !changedAddressFields.postalCode.geolocationAutoCompleted
     ) {
       const postalCodeField =
-        rules.fields &&
-        rules.fields.find((field) => field.name === 'postalCode')
+        rules.fields && rules.fields.find(field => field.name === 'postalCode')
       const diffFromPrev =
         address.postalCode.value !== validatedAddress.postalCode.value
       const isValidPostalCode = validatedAddress.postalCode.valid === true
+      const isValidCountryCode = validatedAddress.country.valid === true
       const shouldAutoComplete =
         rules.postalCodeFrom === POSTAL_CODE &&
         diffFromPrev &&
         isValidPostalCode &&
+        isValidCountryCode &&
         postalCodeField &&
         postalCodeField.postalCodeAPI
 

--- a/react/AddressContainer.test.js
+++ b/react/AddressContainer.test.js
@@ -8,8 +8,12 @@ import { mount, render } from 'test-utils'
 
 jest.mock('./postalCodeAutoCompleteAddress')
 
-const descendToChild = (wrapper) =>
-  wrapper.children().children().children().children()
+const descendToChild = wrapper =>
+  wrapper
+    .children()
+    .children()
+    .children()
+    .children()
 
 describe('AddressContainer', () => {
   const accountName = 'qamarketplace'
@@ -141,7 +145,10 @@ describe('AddressContainer', () => {
 
       // Act
       const onChangeAddress = descendToChild(wrapper).props().onChangeAddress
-      onChangeAddress({ postalCode: { value: '22231000' } })
+      onChangeAddress({
+        postalCode: { value: '22231000' },
+        country: { value: 'BRA' },
+      })
 
       // Assert
       expect(postalCodeAutoCompleteAddress).toHaveBeenCalled()


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR prevents address-form from trying to autocomplete an address with a `null` country code.
<!--- Describe your changes in detail. -->

#### How should this be manually tested?

- Proceed to the [workspace](https://jeff--vtexgame1.myvtex.com/checkout/cart/add?sku=298&qty=1&seller=1)
- Use `22230001` as postal code to calculate the delivery options.
- Then click on the postal code link to edit the shipping preview
- Copy `22250040` and paste on the postal code input
- The shipping preview should not end up in a loop

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
