### PR TITLE
Fix ARG missing locality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Argentina missing locality.
+
 ## [3.12.4] - 2020-07-09
 
 ### Fixed

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -1006,6 +1006,7 @@ const countryData = {
     'Juan G Pujol',
     'Juan José Almeyra',
     'Juan José Paso',
+    'Jose Leon Suarez',
     'Juan Maria Gutierrez',
     'Juan N Fernández',
     'Juan Tronconi',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Includes a missing locality for Argentina.

The postalCode `1655` is from `"city": "Jose Leon Suarez"` according to the postal-codes service: http://postalcode.vtexcommercestable.com.br/api/postal/pub/address/ARG/1655

#### What problem is this solving?

The localities registered on the checkout application should be synced with the postal-codes autocomplete service in order to your validation to work.

#### How should this be manually tested?

- add to cart: https://garrucho--cuestablanca.myvtex.com/checkout/cart/add?sc=1&sku=8091&qty=1&seller=1
- follow as a new user
- insert the ZIP Code `1655 ` on the shipping step
- go to payment with success

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
