### PR TITLE
Revert country validation in address change handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert validation of country code in address change handler.
+
 ## [3.12.8] - 2020-08-10
 
 ### Fixed
@@ -14,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - State/city selection on Romania because postalCode was not required when it should.
 - Remove USA states as options for South Korea.
 
-## [3.12.7] - 2020-08-07
+## [3.12.7] - 2020-08-07 [YANKED]
 
 ### Fixed
 

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -71,12 +71,10 @@ class AddressContainer extends Component {
       const diffFromPrev =
         address.postalCode.value !== validatedAddress.postalCode.value
       const isValidPostalCode = validatedAddress.postalCode.valid === true
-      const isValidCountryCode = validatedAddress.country.valid === true
       const shouldAutoComplete =
         rules.postalCodeFrom === POSTAL_CODE &&
         diffFromPrev &&
         isValidPostalCode &&
-        isValidCountryCode &&
         postalCodeField &&
         postalCodeField.postalCodeAPI
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Revert changes of #274.

#### What problem is this solving?

Users couldn't go past through Omnishipping address creating step.

#### How this can be manually tested?

Access [this workspace](https://countrynull--vtexgame1.myvtex.com) and make sure you can type the postal code in omnishipping and successfully load the address.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.