### PR TITLE
Fix postal code input loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Endless postal code input loading icon.
+
 ## [3.12.10] - 2020-08-24
 
 ### Changed

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -5,7 +5,9 @@ import get from 'lodash/get'
 import AddressShapeWithValidation from './propTypes/AddressShapeWithValidation'
 import { validateChangedFields } from './validateAddress'
 import { POSTAL_CODE } from './constants'
-import postalCodeAutoCompleteAddress from './postalCodeAutoCompleteAddress'
+import postalCodeAutoCompleteAddress, {
+  removePostalCodeLoading,
+} from './postalCodeAutoCompleteAddress'
 import { AddressContext } from './addressContainerContext'
 import { injectRules } from './addressRulesContext'
 
@@ -79,16 +81,16 @@ class AddressContainer extends Component {
         postalCodeField.postalCodeAPI
 
       if (shouldAutoComplete) {
-        return onChangeAddress(
-          postalCodeAutoCompleteAddress({
-            cors,
-            accountName,
-            address: validatedAddress,
-            rules,
-            callback: this.handleAddressChange,
-            shouldAddFocusToNextInvalidField,
-          }),
-        )
+        const autoCompletedAddress = postalCodeAutoCompleteAddress({
+          cors,
+          accountName,
+          address: validatedAddress,
+          rules,
+          callback: this.handleAddressChange,
+          shouldAddFocusToNextInvalidField,
+        })
+
+        return onChangeAddress(removePostalCodeLoading(autoCompletedAddress))
       }
     }
 

--- a/react/postalCodeAutoCompleteAddress.js
+++ b/react/postalCodeAutoCompleteAddress.js
@@ -76,7 +76,7 @@ function addPostalCodeLoading(address) {
   }
 }
 
-function removePostalCodeLoading(address) {
+export function removePostalCodeLoading(address) {
   return {
     ...address,
     postalCode: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR prevents the postal code input from showing an endless loading icon.

<!--- Describe your changes in detail. -->

#### How should this be manually tested?

- Use this [workspace](https://postalcodeloading--vtexgame1.myvtex.com/checkout/cart/add?sku=298&qty=1&seller=1)
- Type a postal code. e.g `22230001`
- Look for the green check after you finish typing the postal code

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/90245179-8c1c7000-de08-11ea-8d17-95ce19b91e15.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
