### PR TITLE
CHK-347: Fix ARG postal code autocompleted from geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Google geolocation not working for ARG country.
+
 ## [3.12.13] - 2020-09-15
 
 ### Added

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21222,6 +21222,19 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
       required: false,
+      handler: (address) => {
+        return {
+          ...address,
+          postalCode: {
+            ...address.postalCode,
+            value:
+              address.postalCode?.value?.replace(
+                /(?:[a-zA-Z]*)(\d+)(?:[a-zA-Z]*)/,
+                '$1'
+              ) ?? '',
+          },
+        }
+      },
     },
     number: {
       valueIn: 'long_name',

--- a/react/country/__mocks__/usePostalCode.js
+++ b/react/country/__mocks__/usePostalCode.js
@@ -83,9 +83,11 @@ export default {
       types: ['street_number'],
       required: true,
       notApplicable: true,
-      handler: address => {
-        return {...address,
-          number: {...address['number'], notApplicable: true}}
+      handler: (address) => {
+        return {
+          ...address,
+          number: { ...address.number, notApplicable: true },
+        }
       },
     },
     street: {

--- a/react/geolocation/geolocationAutoCompleteAddress.test.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.test.js
@@ -12,7 +12,7 @@ describe('Geolocation Auto Complete Address', () => {
     const address = geolocationAutoCompleteAddress(
       newAddress,
       postalCodeGoogleAddress,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(address).toMatchSnapshot()
@@ -22,7 +22,7 @@ describe('Geolocation Auto Complete Address', () => {
     const address = geolocationAutoCompleteAddress(
       newAddress,
       oneLevelGoogleAddress,
-      useOneLevel,
+      useOneLevel
     )
 
     expect(address.postalCode.value).toBe('0000')
@@ -32,7 +32,7 @@ describe('Geolocation Auto Complete Address', () => {
     const address = geolocationAutoCompleteAddress(
       newAddress,
       invalidFieldGoogleAddress,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(address.postalCode.valid).toBe(false)
@@ -52,7 +52,7 @@ describe('Geolocation Auto Complete Address', () => {
         receiverName: { value: receiverName },
       },
       postalCodeGoogleAddress,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(address.addressId.value).toBe(addressId)
@@ -69,7 +69,7 @@ describe('Geolocation Auto Complete Address', () => {
         complement: { value: complement },
       },
       postalCodeGoogleAddress,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(address.complement).toBeUndefined()
@@ -79,18 +79,7 @@ describe('Geolocation Auto Complete Address', () => {
     const address = geolocationAutoCompleteAddress(
       { ...newAddress },
       postalCodeGoogleAddressNoNumber,
-      usePostalCode,
-    )
-
-    expect(address.number).toBeTruthy()
-    expect(address.number.notApplicable).toBeTruthy()
-  })
-
-  it('should keep number as notApplicable', () => {
-    const address = geolocationAutoCompleteAddress(
-      { ...newAddress },
-      postalCodeGoogleAddressNoNumber,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(address.number).toBeTruthy()


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the ARG geolocation rules for postal code to extract the postal code numbers.

#### What problem is this solving?

Fixes the format of postal code for ARG when using Google geolocation.

#### How should this be manually tested?

[Workspace](https://lucas--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&redirect=true&sc=2).

You can use the following addresses to test, the shipping component should not end up in an error state after the address is autocompleted:

- Rastreador Fournier 3150, B1619 Garin, Buenos Aires, Argentina
- Avenida Santa Fe 1400, Cidade Autônoma de Buenos Aires, Argentina
- Calle Italia 520, Garin, Buenos Aires, Argentina

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
