### PR TITLE
Add className prop to address form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Prop `className` to `AddressForm` component.
+
 ## [3.12.14] - 2020-09-23
 
 ### Fixed

--- a/react/AddressForm.js
+++ b/react/AddressForm.js
@@ -26,6 +26,7 @@ class AddressForm extends Component {
       notApplicableLabel,
       omitPostalCodeFields,
       omitAutoCompletedFields,
+      className,
     } = this.props
 
     let fields = omitPostalCodeFields
@@ -37,7 +38,7 @@ class AddressForm extends Component {
       : fields
 
     return (
-      <div>
+      <div className={className}>
         {fields.map((field) =>
           isDefiningPostalCodeField(field.name, rules) ? (
             <SelectPostalCode
@@ -71,6 +72,7 @@ AddressForm.defaultProps = {
 }
 
 AddressForm.propTypes = {
+  className: PropTypes.string,
   Input: PropTypes.func,
   intl: intlShape,
   address: AddressShapeWithValidation,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `className` prop to `AddressForm` so we can add custom classes to the outer div of the component.

#### What problem is this solving?

Be able to pass in a class to the component outer div.

#### How should this be manually tested?

N/A

#### Screenshots or example usage

N/A

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
