### PR TITLE
Make receiverName required while using geolocation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `receiverName` required while using geolocation input.
+
 ## [3.13.0] - 2020-10-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.13.1] - 2020-10-06
+
 ### Fixed
 
 - Make `receiverName` required while using geolocation input.

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,13 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",
   "mustUpdateAt": "2019-01-08",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "settingsSchema": {},
   "dependencies": {
     "vtex.checkout": "0.x",

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21218,6 +21218,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/BOL.js
+++ b/react/country/BOL.js
@@ -486,6 +486,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/BRA.js
+++ b/react/country/BRA.js
@@ -114,6 +114,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/CAN.js
+++ b/react/country/CAN.js
@@ -99,6 +99,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -501,6 +501,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/COL.js
+++ b/react/country/COL.js
@@ -1280,6 +1280,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/CRI.js
+++ b/react/country/CRI.js
@@ -763,6 +763,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ECU.js
+++ b/react/country/ECU.js
@@ -102,7 +102,7 @@ const countryData = {
     Riobamba: '0004',
     'San Andres': '0004',
     'San Luis': '0004',
-    Yaruquies: '0004'
+    Yaruquies: '0004',
   },
   Cotopaxi: {
     Anchilivi: '0005',
@@ -221,7 +221,6 @@ const countryData = {
     'El Empalme': '0009',
     'El Morro': '0009',
     'El Nato': '0009',
-    'El Triunfo': '0009',
     'El Triunfo': '0009',
     'Eloy Alfaro - Duran': '0009',
     Engabao: '0009',

--- a/react/country/ECU.js
+++ b/react/country/ECU.js
@@ -691,6 +691,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ESP.js
+++ b/react/country/ESP.js
@@ -139,6 +139,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/FRA.js
+++ b/react/country/FRA.js
@@ -66,6 +66,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/GBR.js
+++ b/react/country/GBR.js
@@ -81,6 +81,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/GTM.js
+++ b/react/country/GTM.js
@@ -693,6 +693,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ITA.js
+++ b/react/country/ITA.js
@@ -80,6 +80,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/KOR.js
+++ b/react/country/KOR.js
@@ -82,6 +82,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/MEX.js
+++ b/react/country/MEX.js
@@ -118,6 +118,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/NIC.js
+++ b/react/country/NIC.js
@@ -279,6 +279,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/PER.js
+++ b/react/country/PER.js
@@ -2394,6 +2394,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/PRT.js
+++ b/react/country/PRT.js
@@ -83,6 +83,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/PRY.js
+++ b/react/country/PRY.js
@@ -441,6 +441,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ROU.js
+++ b/react/country/ROU.js
@@ -13989,6 +13989,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/SLV.js
+++ b/react/country/SLV.js
@@ -383,6 +383,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/URY.js
+++ b/react/country/URY.js
@@ -422,6 +422,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/USA.js
+++ b/react/country/USA.js
@@ -146,6 +146,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/VEN.js
+++ b/react/country/VEN.js
@@ -286,6 +286,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -78,6 +78,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],


### PR DESCRIPTION
#### What is the purpose of this pull request?

- ditto.

#### What problem is this solving?

- The `receiverName `is required on the checkout.... vide:

![image](https://user-images.githubusercontent.com/3926634/95127052-c251de00-072d-11eb-9568-110ddc1d67ac.png)

And this rule wasn't being applied while using geolocation.

#### How should this be manually tested?

Try to create an address on this acc: https://storev1--recorrenciaqa.myvtex.com/account

#### Screenshots or example usage

![Screen Shot 2020-10-05 at 5 03 15 PM](https://user-images.githubusercontent.com/3926634/95127205-047b1f80-072e-11eb-8812-08a2755399c9.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
