### PR TITLE
Make receiverName required while using geolocation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `receiverName` required while using geolocation input.
+
 ## [4.6.3] - 2020-07-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.6.4] - 2020-10-06
+
 ### Fixed
 
 - Make `receiverName` required while using geolocation input.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/address-form",
-  "version": "4.6.2",
+  "version": "4.6.4",
   "description": "address-form React component",
   "main": "lib/index.js",
   "files": [

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21217,6 +21217,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/BOL.js
+++ b/react/country/BOL.js
@@ -486,6 +486,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/BRA.js
+++ b/react/country/BRA.js
@@ -114,6 +114,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/CAN.js
+++ b/react/country/CAN.js
@@ -99,6 +99,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -501,6 +501,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/COL.js
+++ b/react/country/COL.js
@@ -1280,6 +1280,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/CRI.js
+++ b/react/country/CRI.js
@@ -763,6 +763,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ECU.js
+++ b/react/country/ECU.js
@@ -393,6 +393,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ESP.js
+++ b/react/country/ESP.js
@@ -139,6 +139,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/FRA.js
+++ b/react/country/FRA.js
@@ -66,6 +66,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/GBR.js
+++ b/react/country/GBR.js
@@ -81,6 +81,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/GTM.js
+++ b/react/country/GTM.js
@@ -665,6 +665,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/KOR.js
+++ b/react/country/KOR.js
@@ -136,6 +136,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/MEX.js
+++ b/react/country/MEX.js
@@ -118,6 +118,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/NIC.js
+++ b/react/country/NIC.js
@@ -279,6 +279,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/PER.js
+++ b/react/country/PER.js
@@ -2394,6 +2394,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/PRT.js
+++ b/react/country/PRT.js
@@ -83,6 +83,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/PRY.js
+++ b/react/country/PRY.js
@@ -441,6 +441,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/ROU.js
+++ b/react/country/ROU.js
@@ -13988,6 +13988,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/SLV.js
+++ b/react/country/SLV.js
@@ -383,6 +383,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/URY.js
+++ b/react/country/URY.js
@@ -422,6 +422,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/USA.js
+++ b/react/country/USA.js
@@ -146,6 +146,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/VEN.js
+++ b/react/country/VEN.js
@@ -286,6 +286,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -78,6 +78,9 @@ export default {
     },
   ],
   geolocation: {
+    receiverName: {
+      required: true,
+    },
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],


### PR DESCRIPTION
#### What is the purpose of this pull request?

- ditto.

#### What problem is this solving?

- The `receiverName `is required on the checkout.... vide:

![image](https://user-images.githubusercontent.com/3926634/95127052-c251de00-072d-11eb-9568-110ddc1d67ac.png)

And this rule wasn't being applied while using geolocation.

#### How should this be manually tested?

Try to create an address on this acc: https://storev1--recorrenciaqa.myvtex.com/account

#### Screenshots or example usage

![Screen Shot 2020-10-05 at 5 03 15 PM](https://user-images.githubusercontent.com/3926634/95127205-047b1f80-072e-11eb-8812-08a2755399c9.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
