### PR TITLE
Fix Guatemala postalCode RegEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Guatemala postalCode's RegEx to allow 6-digit options.
+
 ## [3.13.4] - 2020-10-21
 
 ### Update

--- a/react/country/GTM.js
+++ b/react/country/GTM.js
@@ -622,7 +622,7 @@ export default {
       name: 'postalCode',
       postalCodeAPI: false,
       required: true,
-      regex: /^[\d]{4,5}$/,
+      regex: /^[\d]{4,6}$/,
       size: 'small',
     },
     {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the locality selection for Guatemala.

#### What problem is this solving?

When changing between the new localities, included in the PR #285, nothing is happening. These localities have 6-digit postalCodes, that weren't covered by the RegEx, so they were invalid and being disconsidered.

#### How should this be manually tested?

The changes are linked in this account/workspace: https://address--latorremx.myvtex.com/checkout/cart/add/?sku=2321&qty=1&seller=1&sc=1&sku=1&qty=1&seller=1&sc=1

You can test it going into the checkouts' shipping step and changing between the new locations. Consider the "Mixco Zona XX" options for that.

![image](https://user-images.githubusercontent.com/7749043/96906647-7e224580-1470-11eb-8533-5411f91ae518.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
