### PR TITLE
Bugfix/postal code locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalid postal code locator URL
+
 ## [4.6.4] - 2020-10-06 [YANKED]
 
 ### Fixed

--- a/react/country/BRA.js
+++ b/react/country/BRA.js
@@ -22,7 +22,7 @@ export default {
       regex: '^([\\d]{5})\\-?([\\d]{3})$',
       postalCodeAPI: true,
       forgottenURL:
-        'http://www.buscacep.correios.com.br/servicos/dnec/index.do',
+        'https://buscacepinter.correios.com.br/app/endereco/index.php',
       size: 'small',
       autoComplete: 'nope',
     },

--- a/react/country/__mocks__/usePostalCode.js
+++ b/react/country/__mocks__/usePostalCode.js
@@ -14,7 +14,7 @@ export default {
       regex: '^([\\d]{5})\\-?([\\d]{3})$',
       postalCodeAPI: true,
       forgottenURL:
-        'http://www.buscacep.correios.com.br/servicos/dnec/index.do',
+        'https://buscacepinter.correios.com.br/app/endereco/index.php',
       size: 'small',
     },
     {


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Replace old shipping simulator `Não sei meu CEP` link, which was linking to an invalid page

#### What problem is this solving?

- Shipping simulator `Não sei meu CEP` link isn't working properly

#### How should this be manually tested?

Locate shipping simulator and then click in `Não sei meu CEP` and assert if the opened page is valid

#### Screenshots or example usage

- Before:

> https://nimb.ws/0qAItv

- After:

> https://nimb.ws/GpdEaM

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
