### PR TITLE
Fix city for Argentina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix "Rosario" (Santa Fé) city in Argentina to "Rosário".
 ## [3.13.10] - 2021-01-04
 
 ### Fixed

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -17172,7 +17172,7 @@ const countryData = {
     'Rodolfo Alcorta',
     'Roldan',
     'Romang',
-    'Rosario',
+    'Rosário',
     'Rueda',
     'Rufino',
     'Ruinas Santa Fe La Vieja',


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix "Rosario" (Santa Fé) city in Argentina to "Rosário", matching the information from postal-codes API: http://postalcode.vtexcommercestable.com.br/api/postal/pub/address/ARG/2000

#### What problem is this solving?

The city is automatically selected after inserting the postalCode, so the city field stays hidden. When there's no matching between the API response and the UI options, the user can't go to payment. No error will be generated and the shopper is stuck on the shipping step.

#### How should this be manually tested?

- add an item to the cart: https://arg--vtexgame1.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
- go to the shipping step and select Argentina as country
- insert the postalCode `2000` (city and state will be auto-filled)
- complete the address (street and number)
- try to go to the payment step

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
