### PR TITLE
Fix state/city selection for Bolivia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- State/city selection on Bolivia because postalCode was not required when it should.
 ## [3.13.11] - 2021-01-14
 
 ### Fixed

--- a/react/country/BOL.js
+++ b/react/country/BOL.js
@@ -420,6 +420,7 @@ export default {
       postalCodeAPI: false,
       regex: /^(\d{5})$/,
       size: 'small',
+      required: true,
     },
     {
       name: 'street',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Absolutely the same as #278, but for Bolivia.

#### What problem is this solving?

Customer from Bolivia can't change their location after the first input.

#### How should this be manually tested?

- using [this cart](https://garrucho--offcorssbo.myvtex.com/checkout/cart/add/?sku=995716&qty=1&seller=1&sc=1)
- for the document field use `111111` and phone `2 222-2222`
- go to shipping step
- select any _departamento_, _provincia_ and _ciudad_
- change state _departamento_ or _provincia_; fields below them should go empty

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
