### PR TITLE
CHK-482: Add address rules for India

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Rules for India.
+
 ## [3.14.1] - 2021-01-19
 
 ### Added

--- a/react/countries.js
+++ b/react/countries.js
@@ -12,6 +12,7 @@ import ESP from './country/ESP'
 import FRA from './country/FRA'
 import GBR from './country/GBR'
 import GTM from './country/GTM'
+import IND from './country/IND'
 import KOR from './country/KOR'
 import MEX from './country/MEX'
 import PER from './country/PER'
@@ -36,6 +37,7 @@ export default {
   FRA,
   GBR,
   GTM,
+  IND,
   KOR,
   MEX,
   PER,

--- a/react/country/IND.js
+++ b/react/country/IND.js
@@ -1,0 +1,147 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'IND',
+  abbr: 'IN',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 50,
+      label: 'postalCode',
+      size: 'small',
+      regex: '^[1-9][0-9]{5}$',
+      autoComplete: 'nope',
+      postalCodeAPI: false,
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+    street: { valueIn: 'long_name', types: ['route'] },
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+  },
+  summary: [
+    [
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
+    ],
+    [
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
+    ],
+  ],
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds the address rules for India, including the postal code regex.

#### What problem is this solving?

Fixes users unable to proceed the shipping step when using the geolocation option.

#### How should this be manually tested?

[Geolocation workspace](https://lucas--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2), [postal code workspace](https://lucas--vtexgame1.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2).

For the geolocation, you can use the address "Kharghar sector 19" and select the first option, and for the postal code you can use "410210".

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
