### PR TITLE
CHK-524: Add rules for San Marino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Rules for San Marino.
+
+### Changed
+
+- Update `AddressContainer` to pass remaining arguments of `onChangeAddress` to prop.
+
 ## [3.14.3] - 2021-01-22
 
 ### Fixed

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -34,7 +34,7 @@ class AddressContainer extends Component {
     }
   }
 
-  handleAddressChange = (changedAddressFields) => {
+  handleAddressChange = (changedAddressFields, ...args) => {
     const {
       cors,
       accountName,
@@ -51,10 +51,13 @@ class AddressContainer extends Component {
       changedAddressFields.country.value !== address.country.value
 
     if (countryChanged) {
-      return onChangeAddress({
-        ...address,
-        ...changedAddressFields,
-      })
+      return onChangeAddress(
+        {
+          ...address,
+          ...changedAddressFields,
+        },
+        ...args
+      )
     }
 
     const validatedAddress = validateChangedFields(
@@ -93,11 +96,14 @@ class AddressContainer extends Component {
           shouldAddFocusToNextInvalidField,
         })
 
-        return onChangeAddress(removePostalCodeLoading(autoCompletedAddress))
+        return onChangeAddress(
+          removePostalCodeLoading(autoCompletedAddress),
+          ...args
+        )
       }
     }
 
-    onChangeAddress(validatedAddress)
+    onChangeAddress(validatedAddress, ...args)
   }
 
   render() {

--- a/react/countries.js
+++ b/react/countries.js
@@ -19,6 +19,7 @@ import PER from './country/PER'
 import PRT from './country/PRT'
 import PRY from './country/PRY'
 import ROU from './country/ROU'
+import SMR from './country/SMR'
 import URY from './country/URY'
 import USA from './country/USA'
 import VEN from './country/VEN'
@@ -44,6 +45,7 @@ export default {
   PRT,
   PRY,
   ROU,
+  SMR,
   URY,
   USA,
   VEN,

--- a/react/country/SMR.js
+++ b/react/country/SMR.js
@@ -1,0 +1,146 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'SMR',
+  abbr: 'SM',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 50,
+      label: 'postalCode',
+      size: 'small',
+      regex: /^\d{5}$/,
+      autoComplete: 'nope',
+      postalCodeAPI: false,
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+    street: { valueIn: 'long_name', types: ['route'] },
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+  },
+  summary: [
+    [
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
+    ],
+    [
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
+    ],
+  ],
+}

--- a/react/country/SMR.js
+++ b/react/country/SMR.js
@@ -65,7 +65,6 @@ export default {
       name: 'state',
       maxLength: 100,
       label: 'state',
-      required: true,
       size: 'large',
     },
     {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add custom rules for the San Marino country, and pass remaining arguments from `AddressContainer#onChangeAddress` to the `onChangeAddress` prop.

#### What problem is this solving?

When using geolocation, the number field wasn't being shown for a San Marino address, even when the autocompleted address didn't include the number.

#### How should this be manually tested?

[Workspace](https://lucas--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&sc=2).

You can use the following address to verify the number input is being shown:

- Viale Antonio Onofri, 47890 Città di San Marino

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
