### PR TITLE
Fix state/city selection for Venezuela

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- State/city selection on Venezuela because postalCode was not required when it should.
+
 ## [3.14.2] - 2021-01-19
 
 ### Added

--- a/react/country/VEN.js
+++ b/react/country/VEN.js
@@ -222,6 +222,7 @@ export default {
       postalCodeAPI: false,
       regex: /^\d{4}$/,
       size: 'small',
+      required: true,
     },
     {
       name: 'street',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Again, the same as #278 (and #310), but for Venezuela.

Note: I've reviewed other countries that could have the same problem (considering the usage of locations from a predefined tree, and the lack of `required: true` on the postalCode field configuration), as PRY, but it doesn't happen for it. 😐  It seems that VEN was the last country with this bad behavior.

#### What problem is this solving?

Customers from Venezuela can't change their location after the first input.

#### How should this be manually tested?

- using [this cart](https://garrucho--vtexgame1.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2)
- go to shipping step
- select "Venezuela" as country
- select any _region_ and _city_
- change the _region_ field; the _city_ field should go empty

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
