### PR TITLE
CHK-520: Fix address autocomplete for Argentina capital

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Address autocomplete for Argentina's capital.
+
 ## [3.15.0] - 2021-01-25
 
 ### Added

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -1,6 +1,11 @@
 import { getOneLevel, getTwoLevels } from '../transforms/addressFieldsOptions'
 import { POSTAL_CODE } from '../constants'
 
+const isCABA = (googleAddress) =>
+  !!googleAddress?.address_components?.find(
+    (component) => component.short_name === 'CABA'
+  )
+
 const countryData = {
   'Ciudad Autónoma de Buenos Aires': ['Ciudad Autónoma de Buenos Aires'],
   'Buenos Aires': [
@@ -21257,10 +21262,28 @@ export default {
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
+      handler: (address, googleAddress) => {
+        if (isCABA(googleAddress)) {
+          address.state = { value: 'Ciudad Autónoma de Buenos Aires' }
+
+          return address
+        }
+
+        return address
+      },
     },
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+      handler: (address, googleAddress) => {
+        if (isCABA(googleAddress)) {
+          address.city = { value: 'Ciudad Autónoma de Buenos Aires' }
+
+          return address
+        }
+
+        return address
+      },
     },
   },
   summary: [


### PR DESCRIPTION
#### What is the purpose of this pull request?

Replaces the state and city of the autocompleted address from Google when it contains the city "CABA" to the mapped name for the capital of Argentina.

#### What problem is this solving?

Fixes the address autocomplete for the capital of Argentina.

#### How should this be manually tested?

[Workspace](https://lucas--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2).

Use the following address: Avenida Santa Fe 2867.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
