### PR TITLE
add La Loma city into col country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `La Loma` city to COL file.
+
 ## [3.15.2] - 2021-02-18
 
 ### Added

--- a/react/country/COL.js
+++ b/react/country/COL.js
@@ -480,6 +480,7 @@ const countryData = {
     González: '20310',
     'La Gloria': '20383',
     'La Jagua De Ibirico': '20400',
+    'La Loma': '20250',
     'La Paz': '20621',
     'Manaure Balcón Del Cesar': '20443',
     Pailitas: '20517',


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds the La Loma city into COL country.

#### What problem is this solving?
Some customers can`t find the La Loma city to send their purchases to La Loma city. It wasn't in the form.
It is importante to noticed that the code for this city is the same as El Paso. This happens because for Colombia, they have the same administrational code, but the ZIP Postal is different. See the reference at _Screenshots or example usage-.

#### How should this be manually tested?

#### Screenshots or example usage
For El Paso you can find three different ZIP Postal code, but only one code for the Administration area:
![image](https://user-images.githubusercontent.com/20197808/109187296-8537c800-7770-11eb-9365-85670226ef83.png)
![image](https://user-images.githubusercontent.com/20197808/109187001-40ac2c80-7770-11eb-91b7-5e80a0af124b.png)
![image](https://user-images.githubusercontent.com/20197808/109187084-53befc80-7770-11eb-92a7-aa04765cd4f4.png)
Here is the website reference: https://col.youbianku.com/pt-pt/taxonomy/term/396


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
