### PR TITLE
Fix creating new address id when editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `postalCodeAutoCompleteAddress` ignoring provided `addressId`.
+
 ## [4.7.0] - 2021-04-19
 
 ### Added
 
 - Add RUS for RUSSIA.
-- Applies a behavior where the postal code isnt required, adding them as ROU example. 
+- Applies a behavior where the postal code isnt required, adding them as ROU example.
 
 ## [4.6.7] - 2021-03-23
 
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Missing countries from 3.x: ARE, DNK, FIN, IND, ITA, SMR and SWE.
+
 ## [4.6.4] - 2020-10-06 [YANKED]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.7.1] - 2021-04-29
+
 ### Fixed
 
 - `postalCodeAutoCompleteAddress` ignoring provided `addressId`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/postalCodeAutoCompleteAddress.js
+++ b/react/postalCodeAutoCompleteAddress.js
@@ -43,6 +43,7 @@ export default function postalCodeAutoCompleteAddress({
       const autoCompletedFields = flow(functionsFlow)(responseAddress)
 
       const newAddressWithAutocompletedFields = newAddress({
+        addressId: address.addressId,
         receiverName: address.receiverName,
         ...autoCompletedFields,
       })

--- a/react/postalCodeAutoCompleteAddress.test.js
+++ b/react/postalCodeAutoCompleteAddress.test.js
@@ -77,7 +77,7 @@ describe('postalCodeAutoCompleteAddress()', () => {
     })
   })
 
-  it.only('should keep address id when auto completing fields', done => {
+  it('should keep address id when auto completing fields', done => {
     const addressId = 'addressId1autoComplete'
     const modifiedAddress = {
       ...address,

--- a/react/postalCodeAutoCompleteAddress.test.js
+++ b/react/postalCodeAutoCompleteAddress.test.js
@@ -76,4 +76,26 @@ describe('postalCodeAutoCompleteAddress()', () => {
       callback,
     })
   })
+
+  it.only('should keep address id when auto completing fields', done => {
+    const addressId = 'addressId1autoComplete'
+    const modifiedAddress = {
+      ...address,
+      addressId: { value: addressId },
+      postalCode: { value: '22251000' },
+    }
+
+    function callback(data) {
+      expect(data.addressId.value).toBe(addressId)
+      done()
+    }
+
+    postalCodeAutoCompleteAddress({
+      cors,
+      accountName,
+      address: modifiedAddress,
+      rules: usePostalCode,
+      callback,
+    })
+  })
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?

The title is self-explanatory.

#### What problem is this solving?

When editing an address' postal code, it's `addressId` is already set but the `postalCodeAutoCompleteAddress` function was ignoring its existence and always creating a new one.

#### How should this be manually tested?

You can use the following workspace: https://arthur--recorrenciaqa.myvtex.com/account. Try creating an address and then editing its postal code. Currently, because the `address-form` ignores the current `addressId` and creates a new one, a new address is created, instead of editing the already existent one.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
