### PR TITLE
[3.x] [OMS-1167] Fixed CHL rules for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed 
 
-- `CHL` rules for feeling data with Google Maps.
+- `CHL` rules when filling data with Google Maps.
 
 ## [3.16.1] - 2021-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+
+- `CHL` rules for feeling data with Google Maps.
+
 ## [3.16.1] - 2021-04-29
 
 ### Fixed

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -66,6 +66,21 @@ const countryData = {
     Tiltil: '9420000',
     Vitacura: '7630000',
   },
+  'Los Ríos': {
+    Coñaripe: '5210001',
+    Corral: '5190000',
+    Futrono: '5180000',
+    'La Union': '5220000',
+    'Lago Ranco': '5250000',
+    Lanco: '5160000',
+    'Los Lagos': '5170000',
+    Mafil: '5200000',
+    Mariquina: '5150000',
+    Paillaco: '5230000',
+    Panguipulli: '5210000',
+    'Rio Bueno': '5240000',
+    Valdivia: '5090000',
+  },
   'I Región': {
     Camiña: '1150000',
     Colchane: '1160000',
@@ -371,7 +386,7 @@ const countryData = {
     Timaukel: '6320000',
     'Torres Del Paine': '6170000',
   },
-  'Los Ríos': {
+  'XIV Región': {
     Coñaripe: '5210001',
     Corral: '5190000',
     Futrono: '5180000',

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -2,6 +2,9 @@ import { TWO_LEVELS } from '../constants'
 import { secondLevelPostalCodes } from '../transforms/postalCodes'
 import { getOneLevel, getTwoLevels } from '../transforms/addressFieldsOptions'
 
+// Based on: https://docs.google.com/spreadsheets/d/1B_e735h3IP1ttom3i55WytSDhH7MZtsOu8Ul5p2wHNI/edit#gid=0
+// More info: https://vtex.slack.com/archives/C3Q96AB1B/p1619724858102700
+
 const countryData = {
   'Región Metropolitana': {
     Alhué: '9650000',
@@ -368,7 +371,7 @@ const countryData = {
     Timaukel: '6320000',
     'Torres Del Paine': '6170000',
   },
-  'XIV Región': {
+  'Los Ríos': {
     Coñaripe: '5210001',
     Corral: '5190000',
     Futrono: '5180000',
@@ -506,6 +509,27 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
       required: false,
+      handler: (address) => {
+        if (
+          !address.state ||
+          !address.state.value ||
+          !address.neighborhood ||
+          !address.neighborhood.value
+        ) {
+          return address
+        }
+
+        if (
+          countryData[address.state.value] &&
+          countryData[address.state.value][address.neighborhood.value]
+        ) {
+          address.postalCode = {
+            value: countryData[address.state.value][address.neighborhood.value],
+          }
+        }
+
+        return address
+      },
     },
     number: {
       valueIn: 'long_name',

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -526,8 +526,10 @@ export default {
       required: false,
       handler: (address) => {
         if (
-          !address.state?.value ||
-          !address.neighborhood?.value
+          !address.state ||
+          !address.state.value ||
+          !address.neighborhood ||
+          !address.neighborhood.value
         ) {
           return address
         }

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -511,10 +511,8 @@ export default {
       required: false,
       handler: (address) => {
         if (
-          !address.state ||
-          !address.state.value ||
-          !address.neighborhood ||
-          !address.neighborhood.value
+          !address.state?.value ||
+          !address.neighborhood?.value
         ) {
           return address
         }


### PR DESCRIPTION
#### What is the purpose of this pull request?

- FIx https://vtex-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=109&modal=detail&selectedIssue=OMS-1167

#### What problem is this solving?

- We weren't able to save the address "Río Loa 689, Valdivia, Valdivia, Chile" because the state info wasn't correctly set.

#### How should this be manually tested?

- Try to add this address on this workspace: 

https://felipe--geraldinemolina.myvtex.com/account#/addresses

Same as: https://github.com/vtex/address-form/pull/340

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
