### PR TITLE
CHK-618: Fix valid address not being updated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Valid address with `valid: false` fields not correctly updated to have
+  `valid: true` in all fields.
+
 ## [3.16.5] - 2021-05-27
 
 ### Added
@@ -22,7 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.16.3] - 2021-05-13
 
 ### Fixed
+
 - Ensure the `state` field is populate when user visits `addresses` inside their account for `RUS`.
+
 ## [3.16.2] - 2021-05-12
 
 ### Fixed 

--- a/react/transforms/address.js
+++ b/react/transforms/address.js
@@ -176,7 +176,7 @@ export function addFocusToNextInvalidField(fields, rules) {
     }
   }
 
-  return fields
+  return addNewField(fields, 'valid', true)
 }
 
 function getFirstInvalidFilledField(fields, rules) {

--- a/react/transforms/address.test.js
+++ b/react/transforms/address.test.js
@@ -254,7 +254,20 @@ describe('Address Transform', () => {
 
       const newFields = addFocusToNextInvalidField(fields, rules)
 
-      expect(newFields).toBe(fields)
+      expect(newFields).toEqual({
+        street: {
+          value: 'Praia de Botafogo',
+          valid: true,
+        },
+        number: {
+          value: '300',
+          valid: true,
+        },
+        state: {
+          value: 'RJ',
+          valid: true,
+        },
+      })
     })
 
     it('should add focus if field is filled but is invalid', () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the `isValidAddress` function to return a valid address with all field 
with `valid: true` instead of returning the input address.

#### What problem is this solving?

Solves an issue where checkout's shipping would update the receiver name of the 
address but would keep the `valid` flag as `false`, so when we try to validate 
the address to proceed to payment the user is required to click the field so it 
is updated before proceeding.

#### How should this be manually tested?

You can use the same test plan as vtex/shipping-manager#75

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
