### PR TITLE
CHK-758: Address mismatch between Google Maps response and the option lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Address mismatch between Google Maps response and the option lists
+
 ## [3.16.6] - 2021-06-01
 
 ### Fixed
@@ -34,7 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.16.2] - 2021-05-12
 
-### Fixed 
+### Fixed
 
 - `CHL` rules when filling data with Google Maps.
 
@@ -49,7 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add RUS for RUSSIA.
-- Applies a behavior where the postal code isnt required, adding them as ROU example. 
+- Applies a behavior where the postal code isnt required, adding them as ROU example.
 
 ## [3.15.6] - 2021-03-25
 
@@ -61,7 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Change regions in CHL file. 
+- Change regions in CHL file.
 
 ## [3.15.4] - 2021-03-05
 

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -196,6 +196,11 @@ function defaultValidation(value, name, address, rules) {
     return emptyField
   }
 
+  // there is no necessity to validate what comes from google maps
+  if (address[name]?.geolocationAutoCompleted) {
+    return validResult
+  }
+
   if (field && hasOptions(field)) {
     return validateOptions(value, field, address, rules)
   }

--- a/react/validateAddress.test.js
+++ b/react/validateAddress.test.js
@@ -440,4 +440,33 @@ describe('Address Validation:', () => {
 
     expect(result.postalCode.valid).toBe(false)
   })
+
+  it('should validate if a field was autocompleted by geolocation', () => {
+    const geolocationAddress = {
+      ...address,
+      state: {
+        value: 'Santa Fe',
+        geolocationAutoCompleted: true,
+      },
+    }
+
+    const rules = {
+      fields: [
+        {
+          name: 'state',
+          required: true,
+          options: ['Santa Fé'],
+        },
+      ],
+    }
+
+    const validOption = validateField(
+      'Santa Fe',
+      'state',
+      geolocationAddress,
+      rules
+    )
+
+    expect(validOption.valid).toBe(true)
+  })
 })


### PR DESCRIPTION
#### What is the purpose of this pull request and what problem is this solving?

[_Copied from the Jira task_](https://vtex-dev.atlassian.net/browse/CHK-758)

Google Maps, as address provider, is returning the "states" from Argentina as "Provincia de {state}" or just returning different values at all, like minor state/city name updates. This is creating two issues while inserting an address:

1. Our UI requires a match between this value and the options mapped on the UI application. When there's no match, we can have side effects as:
	- The address will be silently invalid, and the shopper can't go ahead with the purchase flow. They need to edit the address to see the wrong field and fix it to a valid option.
	- It seems to impact more the form for the invoice address (which can be required when purchasing via pickup point option) than the shipping address.
	- When going to edit the address, the value for the unmatched field will present the first option from the list as selected. Ideally, it should match the correct value, but in the case that it isn't possible, the field should come empty.
2. External environments, such as the Cybersouce antifraud, expect the state just as "Buenos Aires" instead of "Provincia de Buenos Aires". While relying on the Google Maps address, some incompatibilities may appear. It's hard to normalize them since different services can expect different values for different fields, and even Google can change their response for specific addresses, but it's especially sensible for the "state" information.

---

This PR fixes this by ignoring the VTEX option list for states and cities when an address is autocompleted for geolocation (except for empty values, so a state shouldn't be an empty string, for example).

The downside with this solution is that we are fully trusting that the Google API is returning the correct data. But at the end of the day, their address database is most reliable than ours, so this shouldn't be a problem.

#### How should this be manually tested?

This is the [same example Garrucho gave on Jira](https://vtex-dev.atlassian.net/browse/CHK-758?focusedCommentId=32103).

- https://argentina--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
- Go to the shipping step inside the checkout
- Insert shipping address `Calle 77 526, Villa Elvira, Provincia de Buenos Aires, Argentina`. **Everything should work as expected**
- Click to edit address
- Insert `Gobernador Iriondo 2300, Santo Tomé, Santa Fe, Argentina`
- Google returns `Santa Fe`, but the value among our options is `Santa Fé`. This mismatch must be ignored and you should be able to proceed to the payment step.

Repeat the same test for the invoice address.

Before | After
-|-
![image](https://user-images.githubusercontent.com/26108090/120491599-5f314d80-c387-11eb-9fec-15376852cd50.png) | ![Screen Shot 2021-06-02 at 09 47 45](https://user-images.githubusercontent.com/26108090/120491868-969ffa00-c387-11eb-84f4-33716cff7f47.png)

