### PR TITLE
CHK-769: Splunk logs for geolocation address mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+- Splunk log on address mismatch between Google Maps response and the option lists
+
 ## [3.16.7] - 2021-06-08
 
 ### Added
@@ -40,7 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.16.2] - 2021-05-12
 
-### Fixed 
+### Fixed
 
 - `CHL` rules when filling data with Google Maps.
 
@@ -55,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add RUS for RUSSIA.
-- Applies a behavior where the postal code isnt required, adding them as ROU example. 
+- Applies a behavior where the postal code isnt required, adding them as ROU example.
 
 ## [3.15.6] - 2021-03-25
 
@@ -67,7 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Change regions in CHL file. 
+- Change regions in CHL file.
 
 ## [3.15.4] - 2021-03-05
 

--- a/react/__mocks__/metrics.js
+++ b/react/__mocks__/metrics.js
@@ -1,0 +1,1 @@
+export function logGeolocationAddressMismatch() {}

--- a/react/__mocks__/splunk-events.js
+++ b/react/__mocks__/splunk-events.js
@@ -1,0 +1,5 @@
+class SplunkEvents {
+  config() {}
+}
+
+export default SplunkEvents

--- a/react/metrics.ts
+++ b/react/metrics.ts
@@ -1,0 +1,75 @@
+import SplunkEvents from 'splunk-events'
+
+export const TYPES = {
+  INFO: 'Info',
+  WARNING: 'Warning',
+  ERROR: 'Error',
+  FATAL: 'Fatal',
+}
+
+export const LEVELS = {
+  DEBUG: 'Debug',
+  DEFAULT: 'Default',
+  IMPORTANT: 'Important',
+  CRITICAL: 'Critical',
+}
+
+interface CustomWindow extends Window {
+  vtex?: {
+    accountName?: string
+    vtexid?: {
+      accountName?: string
+    }
+  }
+  vtexjs?: {
+    checkout?: {
+      orderFormId?: string
+    }
+  }
+  __RENDER_7_COMPONENTS__?: Record<string, unknown>
+}
+
+declare let window: CustomWindow
+
+const splunkEvents = new SplunkEvents()
+
+splunkEvents.config({
+  endpoint: 'https://splunk-heavyforwarder-public.vtex.com:8088',
+  token: '50fe94b0-30b6-442a-9cb1-a476c97ba917',
+  headers: {
+    'Content-Type': 'text/plain',
+  },
+})
+
+function getAccountName() {
+  return window.vtex?.accountName ?? window?.vtex?.vtexid?.accountName
+}
+
+interface LogGeolocationAddressMismatchData {
+  fieldValue: string
+  fieldName: string
+  country: string
+  address: Record<string, unknown>
+}
+
+export function logGeolocationAddressMismatch(
+  data: LogGeolocationAddressMismatchData
+) {
+  const serializedAddress = JSON.stringify(data.address)
+
+  const eventData = {
+    ...data,
+    address: serializedAddress,
+    orderFormId: window.vtexjs?.checkout?.orderFormId ?? '',
+    addressFormVersion: process.env.VTEX_APP_VERSION ?? '',
+  }
+
+  splunkEvents.logEvent(
+    LEVELS.DEBUG,
+    TYPES.WARNING,
+    'address-form',
+    'validate-field',
+    eventData,
+    getAccountName()
+  )
+}

--- a/react/package.json
+++ b/react/package.json
@@ -43,6 +43,7 @@
     "@types/jest": "^26.0.19",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@vtex/tsconfig": "^0.5.6",
     "babel-jest": "^26.3.0",
     "enzyme": "^3.4.1",
     "enzyme-adapter-react-16": "^1.8.0",
@@ -53,7 +54,8 @@
     "jest-enzyme": "^7.1.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-test-renderer": "^16.7.0"
+    "react-test-renderer": "^16.7.0",
+    "typescript": "3.9.7"
   },
   "resolutions": {
     "jest-environment-jsdom": "^26.3.0"

--- a/react/package.json
+++ b/react/package.json
@@ -28,7 +28,8 @@
     "lodash": "^4.17.4",
     "msk": "1.0.3",
     "react-intl": "^2.8.0",
-    "recompose": "^0.27.1"
+    "recompose": "^0.27.1",
+    "splunk-events": "1.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -100,7 +101,7 @@
       "\\.(css|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)(\\?.*)?$": "identity-obj-proxy"
     },
     "transform": {
-      "^.+\\.jsx?$": "<rootDir>/jest.transform.js"
+      "^.+\\.(j|t)sx?$": "<rootDir>/jest.transform.js"
     }
   }
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@vtex/tsconfig",
+  "compilerOptions": {
+    "lib": ["DOM"],
+    "allowJs": true,
+    "strict": true,
+    "outDir": "dist/",
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5880,6 +5880,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+splunk-events@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.6.0.tgz#cd4b93d6a5fcd78ba88ad2cc7821a7d26ceb0c66"
+  integrity sha512-SGTZatld08W2P1GaLadtWKbUHAFM4M12hTNWYCcXGWVzmQC+lH5GxrjW1oRCEeLuJ3eBoue0N5spJuDR0wABNA==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1514,6 +1514,11 @@
     vtex-tachyons "^3.2.0"
     whatwg-fetch "2.0.4"
 
+"@vtex/tsconfig@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.6.tgz#c0eb4222a75d1b8a4fefb1d85bbd9349880ddbe5"
+  integrity sha512-3pdtp0QiUjW3YqyA+2YPV3AsAJ68wHWELrg7JMlr7ULHNb4mUfmTBx31zbWG94K3OWp0KJFfF3ytQ+I68foqKA==
+
 abab@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.4.tgz#6dfa57b417ca06d21b2478f0e638302f99c2405c"
@@ -6207,6 +6212,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds splunk-events lib in order to log whenever an address that comes from Google Maps mismatches with some address data that we keep hardcoded. For example, if we expect "Santa Fé" as a valid Argentina state and GMaps returns "Santa Fe" (without the accent), this will be a mismatch.

Also, it uses typescripts for the new  `metrics.ts` file.

#### What problem is this solving?

In order to better understand the frequency and peculiarities of the [Google Maps mismatch Known Issue](https://vtex-dev.atlassian.net/browse/CHK-758), we decided to log all mismatches during geolocation. This will help our investigations to decide on better approaches to solving this problem.

#### How should this be manually tested?

This is the [same example Garrucho gave on Jira](https://vtex-dev.atlassian.net/browse/CHK-758?focusedCommentId=32103).

- https://argentina--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
- Go to the shipping step inside the checkout
- Insert shipping address `Calle 77 526, Villa Elvira, Provincia de Buenos Aires, Argentina`. **Everything should work as expected**
- Click to edit address
- Insert `Gobernador Iriondo 2300, Santo Tomé, Santa Fe, Argentina`
- Google returns `Santa Fe`, but the value among our options is `Santa Fé` (this is where the mismatch happens)
- Run [this query](https://splunk7.vtex.com/en-US/app/vtex_checkout_ui/search?earliest=-15m%40m&latest=now&q=search%20index%3Dcheckout_ui%20workflowInstance%3D%22validate-field%22&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&workload_pool=&display.page.search.tab=statistics&sid=1623164665.2267957_1AEF2693-B8D7-45B3-B372-E433F69F2545) on Splunk. The mismatch above should appear