### PR TITLE
Fix/busca cep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Get Forgotten Postal Code Url for Brazil (Correios).
+
 ## [3.16.8] - 2021-06-08
 
 ## Added

--- a/react/country/BRA.js
+++ b/react/country/BRA.js
@@ -22,7 +22,7 @@ export default {
       regex: '^([\\d]{5})\\-?([\\d]{3})$',
       postalCodeAPI: true,
       forgottenURL:
-        'http://www.buscacep.correios.com.br/servicos/dnec/index.do',
+        '//buscacepinter.correios.com.br',
       size: 'small',
       autoComplete: 'nope',
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the Correios link for a more reliable one. More details on thread:
https://vtex.slack.com/archives/C6HS68DHD/p1620320872261600

#### How should this be manually tested?
- https://forgottencep--vtexgame1.myvtex.com/checkout/cart/add/?sku=318&qty=1&seller=1&sc=1&sku=310&qty=1&seller=1&sc=1
- You can use a random email and profile data
- Proceed to shipping step and click on "Não sei meu CEP" link
- It should open the Correios page in a new tab properly

#### Screenshots or example usage
![forgottenCEP](https://user-images.githubusercontent.com/850280/121381663-4c38f300-c91c-11eb-81ae-2a4ce9ccd660.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
