### PR TITLE
Maps unknown state values to ARG country states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Maps unknown `state` values to `state` options for `ARG` country.
+
 ## [3.16.9] - 2021-06-10
 
 ## Fixed

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -11,7 +11,6 @@ const isCABA = (googleAddress) =>
  */
 
 const mappedStates = {
-  'capital federal': 'Buenos Aires',
   'ciudad autonoma de buenos aires': 'Ciudad Autónoma de Buenos Aires',
   'gran buenos aires': 'Ciudad Autónoma de Buenos Aires',
   'provincia de buenos aires': 'Buenos Aires',

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -6,6 +6,15 @@ const isCABA = (googleAddress) =>
     (component) => component.short_name === 'CABA'
   )
 
+const mappedStates = {
+  'Capital Federal': 'Buenos Aires',
+  'CIUDAD AUTONOMA DE BUENOS AIRES': 'Ciudad Autónoma de Buenos Aires',
+  'Gran Buenos Aires': 'Ciudad Autónoma de Buenos Aires',
+  'Provincia de Buenos Aires': 'Buenos Aires',
+  'Santa Fe': 'Santa Fé',
+  CABA: 'Ciudad Autónoma de Buenos Aires',
+}
+
 const countryData = {
   'Ciudad Autónoma de Buenos Aires': ['Ciudad Autónoma de Buenos Aires'],
   'Buenos Aires': [
@@ -21266,6 +21275,12 @@ export default {
       handler: (address, googleAddress) => {
         if (isCABA(googleAddress)) {
           address.state = { value: 'Ciudad Autónoma de Buenos Aires' }
+
+          return address
+        }
+
+        if (mappedStates[address?.state.value]) {
+          address.state = { value: mappedStates[address?.state.value] }
 
           return address
         }

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -15,7 +15,6 @@ const mappedStates = {
   'ciudad autonoma de buenos aires': 'Ciudad Autónoma de Buenos Aires',
   'gran buenos aires': 'Ciudad Autónoma de Buenos Aires',
   'provincia de buenos aires': 'Buenos Aires',
-  caba: 'Ciudad Autónoma de Buenos Aires',
 }
 
 const countryData = {

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -6,12 +6,16 @@ const isCABA = (googleAddress) =>
     (component) => component.short_name === 'CABA'
   )
 
+/**
+ * This is needed to normalize the values for state returned by GMaps
+ */
+
 const mappedStates = {
   'Capital Federal': 'Buenos Aires',
   'CIUDAD AUTONOMA DE BUENOS AIRES': 'Ciudad Autónoma de Buenos Aires',
   'Gran Buenos Aires': 'Ciudad Autónoma de Buenos Aires',
   'Provincia de Buenos Aires': 'Buenos Aires',
-  'Santa Fe': 'Santa Fé',
+  'Santa Fé': 'Santa Fe',
   CABA: 'Ciudad Autónoma de Buenos Aires',
 }
 
@@ -16404,7 +16408,7 @@ const countryData = {
     'Yegua Muerta',
     'Zanjón Del Pescado',
   ],
-  'Santa Fé': [
+  'Santa Fe': [
     '29',
     '22 De Mayo',
     '4 De Febrero',

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -15,7 +15,6 @@ const mappedStates = {
   'ciudad autonoma de buenos aires': 'Ciudad Autónoma de Buenos Aires',
   'gran buenos aires': 'Ciudad Autónoma de Buenos Aires',
   'provincia de buenos aires': 'Buenos Aires',
-  'santa fé': 'Santa Fe',
   caba: 'Ciudad Autónoma de Buenos Aires',
 }
 

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -11,12 +11,12 @@ const isCABA = (googleAddress) =>
  */
 
 const mappedStates = {
-  'Capital Federal': 'Buenos Aires',
-  'CIUDAD AUTONOMA DE BUENOS AIRES': 'Ciudad Autónoma de Buenos Aires',
-  'Gran Buenos Aires': 'Ciudad Autónoma de Buenos Aires',
-  'Provincia de Buenos Aires': 'Buenos Aires',
-  'Santa Fé': 'Santa Fe',
-  CABA: 'Ciudad Autónoma de Buenos Aires',
+  'capital federal': 'Buenos Aires',
+  'ciudad autonoma de buenos aires': 'Ciudad Autónoma de Buenos Aires',
+  'gran buenos aires': 'Ciudad Autónoma de Buenos Aires',
+  'provincia de buenos aires': 'Buenos Aires',
+  'santa fé': 'Santa Fe',
+  caba: 'Ciudad Autónoma de Buenos Aires',
 }
 
 const countryData = {
@@ -21283,8 +21283,10 @@ export default {
           return address
         }
 
-        if (mappedStates[address?.state.value]) {
-          address.state = { value: mappedStates[address?.state.value] }
+        if (mappedStates[address?.state.value.toLowerCase()]) {
+          address.state = {
+            value: mappedStates[address?.state.value.toLowerCase()],
+          }
 
           return address
         }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR is the start of an effort that will be made in order to map unknown `state` values to known options when using geolocation. More specifically, this maps some values returned by geolocation in country `ARG`.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Use this [workspace](https://jeff--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2)
- Proceed to checkout 
- On the shipping step, change the country to `Argentina`

Case 1:

- Use the address `Int. Agüero 935, Morón, Provincia de Buenos Aires, Argentina`
- Check that the selector of `state` is not enabled.

Case 2:

- Use the address `Montevideo 1132, S2000BRX Rosario, Santa Fe, Argentina`
- Check that the selector of `state` is not enabled and the state "Santa Fé" is shown.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
