### PR TITLE
CHK-769: Improvements on geolocation address mismatch logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Tests for geolocation address mismatch log
+
+### Changed
+
+- Address data is now indexable by Splunk.
+
+### Fixed
+
+- Cities and neighborhoods being wrongfully logged as address mismatches.
+- Account name not being logged when used outside Checkout.
+- Country from rules object is now differentiable from address country on logger.
+- Raised exceptions from Splunk logger breaking the application.
+
 ## [3.16.10] - 2021-06-15
 
 ### Changed

--- a/react/__mocks__/geolocationAddress2.js
+++ b/react/__mocks__/geolocationAddress2.js
@@ -1,0 +1,59 @@
+export default {
+  number: {
+    value: '581',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  street: {
+    value: 'Santa Fe',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  neighborhood: {
+    value: 'Centro',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  city: {
+    value: 'Rosario',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  state: {
+    value: 'Santa Fe',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  postalCode: {
+    value: '2000',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  geoCoordinates: {
+    visited: true,
+    value: [-60.6308774, -32.9473858],
+    geolocationAutoCompleted: true,
+  },
+  country: {
+    value: 'ARG',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  addressQuery: {
+    value: 'ATC, Sta Fe 581, S2000 Rosario, Santa Fe, Argentina',
+    geolocationAutoCompleted: true,
+    visited: true,
+  },
+  addressId: {
+    value: '4870050329076',
+    visited: true,
+  },
+  addressType: {
+    value: 'residential',
+    visited: true,
+  },
+  receiverName: {
+    value: 'auto auto',
+    visited: true,
+  },
+}

--- a/react/__mocks__/metrics.js
+++ b/react/__mocks__/metrics.js
@@ -1,1 +1,0 @@
-export function logGeolocationAddressMismatch() {}

--- a/react/metrics.ts
+++ b/react/metrics.ts
@@ -46,8 +46,8 @@ splunkEvents.config({
 function getAccountName() {
   return (
     window.vtex?.accountName ??
-    window?.vtex?.vtexid?.accountName ??
-    window?.__RUNTIME__?.account
+    window.vtex?.vtexid?.accountName ??
+    window.__RUNTIME__?.account
   )
 }
 

--- a/react/metrics.ts
+++ b/react/metrics.ts
@@ -51,22 +51,36 @@ function getAccountName() {
   )
 }
 
+type EventData = Parameters<typeof splunkEvents.logEvent>[4]
+
 interface LogGeolocationAddressMismatchData {
   fieldValue: string
   fieldName: string
   countryFromRules: string
-  countryFromAddress: string
-  address: Record<string, unknown>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  address: Record<string, any>
 }
 
-export function logGeolocationAddressMismatch(
-  data: LogGeolocationAddressMismatchData
-) {
-  const serializedAddress = JSON.stringify(data.address)
-
-  const eventData = {
-    ...data,
-    address: serializedAddress,
+export function logGeolocationAddressMismatch({
+  fieldValue,
+  fieldName,
+  countryFromRules,
+  address,
+}: LogGeolocationAddressMismatchData) {
+  const eventData: EventData = {
+    fieldValue,
+    fieldName,
+    countryFromRules,
+    query: address.addressQuery?.value ?? '',
+    country: address.country?.value ?? '',
+    state: address.state?.value ?? '',
+    city: address.city?.value ?? '',
+    street: address.street?.value ?? '',
+    number: address.number?.value ?? '',
+    postalCode: address.postalCode?.value ?? '',
+    lat: address.geoCoordinates?.value?.[1] ?? '',
+    lon: address.geoCoordinates?.value?.[0] ?? '',
+    type: address.addressType?.value ?? '',
     orderFormId: window.vtexjs?.checkout?.orderFormId ?? '',
     addressFormVersion: process.env.VTEX_APP_VERSION ?? '',
   }

--- a/react/metrics.ts
+++ b/react/metrics.ts
@@ -54,7 +54,8 @@ function getAccountName() {
 interface LogGeolocationAddressMismatchData {
   fieldValue: string
   fieldName: string
-  country: string
+  countryFromRules: string
+  countryFromAddress: string
   address: Record<string, unknown>
 }
 

--- a/react/metrics.ts
+++ b/react/metrics.ts
@@ -26,7 +26,9 @@ interface CustomWindow extends Window {
       orderFormId?: string
     }
   }
-  __RENDER_7_COMPONENTS__?: Record<string, unknown>
+  __RUNTIME__?: {
+    account?: string
+  }
 }
 
 declare let window: CustomWindow
@@ -42,7 +44,11 @@ splunkEvents.config({
 })
 
 function getAccountName() {
-  return window.vtex?.accountName ?? window?.vtex?.vtexid?.accountName
+  return (
+    window.vtex?.accountName ??
+    window?.vtex?.vtexid?.accountName ??
+    window?.__RUNTIME__?.account
+  )
 }
 
 interface LogGeolocationAddressMismatchData {

--- a/react/metrics.ts
+++ b/react/metrics.ts
@@ -71,12 +71,16 @@ export function logGeolocationAddressMismatch(
     addressFormVersion: process.env.VTEX_APP_VERSION ?? '',
   }
 
-  splunkEvents.logEvent(
-    LEVELS.DEBUG,
-    TYPES.WARNING,
-    'address-form',
-    'validate-field',
-    eventData,
-    getAccountName()
-  )
+  try {
+    splunkEvents.logEvent(
+      LEVELS.DEBUG,
+      TYPES.WARNING,
+      'address-form',
+      'validate-field',
+      eventData,
+      getAccountName()
+    )
+  } catch (error) {
+    // ignore failed log
+  }
 }

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -205,7 +205,6 @@ function defaultValidation(value, name, address, rules) {
         fieldValue: value,
         fieldName: name,
         countryFromRules: rules.country,
-        countryFromAddress: address.country,
         address,
       })
     }

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -201,12 +201,7 @@ function defaultValidation(value, name, address, rules) {
     const result = validateOptions(value, field, address, rules)
 
     if (result === notAnOption && address[name]?.geolocationAutoCompleted) {
-      logGeolocationAddressMismatch({
-        fieldValue: value,
-        fieldName: name,
-        countryFromRules: rules.country,
-        address,
-      })
+      logIfGeolocationAddressMismatchExists(value, name, address, rules)
     }
 
     return result
@@ -268,4 +263,57 @@ function validatePostalCode(value, name, _, rules) {
   }
 
   return validResult
+}
+
+// To explain why this log is necessary, let's suppose that a customer searches
+// for the address "ATC, Sta Fe 581, S2000 Rosario, Santa Fe, Argentina". Google
+// Maps will correctly return "Santa Fe" as a state, but we only have "Santa Fé"
+// (with the accent) on `ARG.js`.
+//
+// This information should be logged as an address mismatch, so we can catch
+// this bug before our clients do.
+//
+// Although this works well for the state field, Google Maps would also return
+// "Rosario" as a city, which we do have properly mapped, but it would still log
+// as a mismatch since we can't find the city in `ARG.js` if we don't have the
+// state match.
+//
+// The function bellow also handles the above scenario, by checking if there was
+// a match in the immediate "superior" administrative area, which is the state
+// field for cities and the city field for neighborhoods.
+function logIfGeolocationAddressMismatchExists(value, name, address, rules) {
+  if (name === 'city') {
+    const stateField = getField('state', rules)
+    const stateResult = validateOptions(
+      address.state.value,
+      stateField,
+      address,
+      rules
+    )
+
+    if (!stateResult.valid) {
+      return
+    }
+  }
+
+  if (name === 'neighborhood') {
+    const cityField = getField('city', rules)
+    const cityResult = validateOptions(
+      address.city.value,
+      cityField,
+      address,
+      rules
+    )
+
+    if (!cityResult.valid) {
+      return
+    }
+  }
+
+  logGeolocationAddressMismatch({
+    fieldValue: value,
+    fieldName: name,
+    countryFromRules: rules.country,
+    address,
+  })
 }

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -204,7 +204,8 @@ function defaultValidation(value, name, address, rules) {
       logGeolocationAddressMismatch({
         fieldValue: value,
         fieldName: name,
-        country: rules.country,
+        countryFromRules: rules.country,
+        countryFromAddress: address.country,
         address,
       })
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?

After analyzing the geolocation address mismatch logs, we realized that it could be improved in few aspects. Most of them are listed [here](https://www.notion.so/vtexhandbook/An-lise-dos-logs-de-mismatch-de-endere-o-retornados-pelo-GMaps-774a257d305a46cfac016dca34b2a945#db93983830fc47ba8cbd1e1abf856023).

Please, refer to the changelog, commit messages and PR comments to understand each improvement.

#### How should this be manually tested?

- https://argentina2--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&redirect=true&sc=2
- Go to the shipping step on checkout
- Select delivery
- Switch country to Mexico
- Query for "Chicoloapan de Juarez - Texcoco de Mora, Salitreria, Texcoco, Méx., Mexico"
- Use [this query](https://splunk7.vtex.com/en-US/app/vtex_checkout_ui/search?q=search%20index%3Dcheckout_ui%20workflowInstance%3D%22validate-field%22%20account%3Dvtexgame1geo%20query%3D%22Chicoloapan%20de%20Juarez%20-%20Texcoco%20de%20Mora%2C%20Salitreria%2C%20Texcoco%2C%20M%C3%A9x.%2C%20Mexico%22&earliest=-5m&latest=now&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&display.general.type=events&display.page.search.tab=events&sid=1623946003.3534437_1AEF2693-B8D7-45B3-B372-E433F69F2545) to find the newly logged mismatch
- Make sure that the log has your orderFormId

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
