### PR TITLE
CHK-799: Add neighborhood to the address summary for ARG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `neighborhood` info to the address summary for the country `ARG`.
+
 ## [3.17.1] - 2021-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `neighborhood` info to the address summary for the country `ARG`.
 
+### Changed
+
+- Now different address fields can have equal `types` property.
+- The precedence present on `types` property will be respected.
+
 ## [3.17.1] - 2021-07-06
 
 ### Changed

--- a/react/AutoCompletedFields.js
+++ b/react/AutoCompletedFields.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import pickBy from 'lodash/pickBy'
-import reduce from 'lodash/reduce'
 import { compose } from 'recompose'
 
 import AddressShapeWithValidation from './propTypes/AddressShapeWithValidation'
@@ -13,22 +12,12 @@ import { injectAddressContext } from './addressContainerContext'
 const IRRELEVANT_FIELDS = ['country', 'geoCoordinates']
 
 const removeAutoCompletedFields = (address) => {
-  return reduce(
-    address,
-    (newAddress, prop, propName) => {
-      if (
-        address[propName].postalCodeAutoCompleted ||
-        address[propName].geolocationAutoCompleted
-      ) {
-        return newAddress
-      }
-
-      newAddress[propName] = { ...prop }
-
-      return newAddress
-    },
-    {}
+  const addressFieldsNotAutoCompleted = Object.entries(address).filter(
+    ([_, value]) =>
+      !value.geolocationAutoCompleted && !value.postalCodeAutoCompleted
   )
+
+  return Object.fromEntries(addressFieldsNotAutoCompleted)
 }
 
 class AutoCompletedFields extends Component {

--- a/react/AutoCompletedFields.js
+++ b/react/AutoCompletedFields.js
@@ -1,21 +1,35 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import pickBy from 'lodash/pickBy'
-import flow from 'lodash/flow'
+import reduce from 'lodash/reduce'
 import { compose } from 'recompose'
 
 import AddressShapeWithValidation from './propTypes/AddressShapeWithValidation'
 import AddressSummary from './AddressSummary'
-import { removeValidation, removeField } from './transforms/address'
+import { removeValidation } from './transforms/address'
 import { injectRules } from './addressRulesContext'
 import { injectAddressContext } from './addressContainerContext'
 
 const IRRELEVANT_FIELDS = ['country', 'geoCoordinates']
 
-const removeAutoCompletedFields = flow([
-  (address) => removeField(address, 'postalCodeAutoCompleted'),
-  (address) => removeField(address, 'geolocationAutoCompleted'),
-])
+const removeAutoCompletedFields = (address) => {
+  return reduce(
+    address,
+    (newAddress, prop, propName) => {
+      if (
+        address[propName].postalCodeAutoCompleted ||
+        address[propName].geolocationAutoCompleted
+      ) {
+        return newAddress
+      }
+
+      newAddress[propName] = { ...prop }
+
+      return newAddress
+    },
+    {}
+  )
+}
 
 class AutoCompletedFields extends Component {
   handleClickChange = (e) => {

--- a/react/AutoCompletedFields.test.js
+++ b/react/AutoCompletedFields.test.js
@@ -113,11 +113,11 @@ describe('AutoCompletedFields', () => {
         'geolocationAutoCompleted',
         undefined
       )
-      expect(onChangeAddressArgument.city).toHaveProperty('value', city)
       expect(onChangeAddressArgument.state).toHaveProperty(
         'postalCodeAutoCompleted',
         undefined
       )
+      expect(onChangeAddressArgument.city).toBeFalsy()
     })
 
     it('should not display country information', () => {

--- a/react/AutoCompletedFields.test.js
+++ b/react/AutoCompletedFields.test.js
@@ -118,6 +118,7 @@ describe('AutoCompletedFields', () => {
         undefined
       )
       expect(onChangeAddressArgument.city).toBeFalsy()
+      expect(onChangeAddressArgument.neighborhood).toBeFalsy()
     })
 
     it('should not display country information', () => {

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21310,6 +21310,10 @@ export default {
     [{ name: 'street' }, { delimiter: ' ', name: 'number' }],
     [{ name: 'complement' }],
     [{ name: 'postalCode' }],
-    [{ name: 'city' }, { delimiter: ', ', name: 'state' }],
+    [
+      { name: 'neighborhood', delimiterAfter: ' - ' },
+      { name: 'city' },
+      { delimiter: ', ', name: 'state' },
+    ],
   ],
 }

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21269,6 +21269,7 @@ export default {
         'sublocality_level_3',
         'sublocality_level_4',
         'sublocality_level_5',
+        'locality',
       ],
     },
     state: {
@@ -21294,7 +21295,7 @@ export default {
     },
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['administrative_area_level_2'],
       handler: (address, googleAddress) => {
         if (isCABA(googleAddress)) {
           address.city = { value: 'Ciudad Autónoma de Buenos Aires' }

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21295,7 +21295,7 @@ export default {
     },
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2'],
+      types: ['administrative_area_level_2', 'locality'],
       handler: (address, googleAddress) => {
         if (isCABA(googleAddress)) {
           address.city = { value: 'Ciudad Autónoma de Buenos Aires' }

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -132,14 +132,15 @@ export default function geolocationAutoCompleteAddress(
 function getAddressComponent(addressComponents, types) {
   let addressComponent
 
-  types.every((type) => {
-    addressComponent = addressComponents.find(
-      (component) =>
-        !!component.types.some((componentType) => componentType === type)
+  for (const type of types) {
+    addressComponent = addressComponents.find((component) =>
+      component.types.includes(type)
     )
 
-    return !addressComponent
-  })
+    if (addressComponent) {
+      return addressComponent
+    }
+  }
 
   return addressComponent
 }

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -38,19 +38,17 @@ export default function geolocationAutoCompleteAddress(
   // from the closure created.
 
   function setAddressFields() {
-    const indexedRules = revertRuleIndex(geolocationRules)
-
-    return googleAddress.address_components.reduce(
-      (updatedAddress, component) => {
-        const checkoutFieldName = getCheckoutFieldName(
-          component.types,
-          indexedRules
+    return Object.entries(geolocationRules).reduce(
+      (updatedAddress, [fieldName, fieldValue]) => {
+        const component = getAddressComponent(
+          googleAddress.address_components,
+          fieldValue.types
         )
 
-        if (checkoutFieldName) {
+        if (component) {
           updatedAddress = setAddressFieldValue(
             updatedAddress,
-            checkoutFieldName,
+            fieldName,
             geolocationRules,
             component
           )
@@ -131,40 +129,19 @@ export default function geolocationAutoCompleteAddress(
   return address
 }
 
-/** This function creates a map like this:
- * {
- *   "postal_code": "postalCode",
- *   "street_number": "number",
- *   "route": "street",
- *   "neighborhood": "neighborhood",
- *   "sublocality_level_1": "neighborhood",
- *   "sublocality_level_2": "neighborhood",
- *   "sublocality_level_3": "neighborhood",
- *   "sublocality_level_4": "neighborhood",
- *   "sublocality_level_5": "neighborhood",
- *   "administrative_area_level_1": "state",
- *   "administrative_area_level_2": "city",
- *   "locality": "city"
- * }
- * So it's easy to find which Google address type matches ours
- */
-function revertRuleIndex(geolocationRules) {
-  return Object.entries(geolocationRules).reduce((acc, [propName, value]) => {
-    for (let i = 0; i < value.types.length; i++) {
-      const type = value.types[i]
+function getAddressComponent(addressComponents, types) {
+  let addressComponent
 
-      acc[type] = propName
-    }
+  types.every((type) => {
+    addressComponent = addressComponents.find(
+      (component) =>
+        !!component.types.some((componentType) => componentType === type)
+    )
 
-    return acc
-  }, {})
-}
+    return !addressComponent
+  })
 
-// Return the matched checkout field name
-function getCheckoutFieldName(types, indexedRules) {
-  const mappedType = types.find((type) => indexedRules[type])
-
-  return mappedType ? indexedRules[mappedType] : null
+  return addressComponent
 }
 
 function setAddressFieldValue(

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -130,10 +130,8 @@ export default function geolocationAutoCompleteAddress(
 }
 
 function getAddressComponent(addressComponents, types) {
-  let addressComponent
-
   for (const type of types) {
-    addressComponent = addressComponents.find((component) =>
+    const addressComponent = addressComponents.find((component) =>
       component.types.includes(type)
     )
 
@@ -142,7 +140,7 @@ function getAddressComponent(addressComponents, types) {
     }
   }
 
-  return addressComponent
+  return undefined
 }
 
 function setAddressFieldValue(


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR does four things:

https://github.com/vtex/address-form/pull/373/commits/cfe28911e7ee0f7a9f2a5868dc6f624261423e61

It adds neighborhood info to the address summary component when the country is `ARG`. With that, the user can now see its neighborhood info on the shipping step.

https://github.com/vtex/address-form/pull/373/commits/1dd7693ac4b26ace480d58a88f8a9f2345ce3fcb

It makes google address component `locality` a possible value for the neighborhood field. This is needed when there's no neighborhood address component on the result from GMaps.

https://github.com/vtex/address-form/pull/373/commits/f0adc15376d83634b155bf9d0cae9a79017d7831

This solves a bug that happens when you insert an address that has `neighborhood` info available,  and then you try to use an address that has no `neighborhood` info. In this case, the new address would reuse the `neighborhood` info from the previous address. Bear in mind that, despite we are talking specifically about `neighborhood` here, this could happen with another field such as `city`.

To achieve that, we could modify the `removeAutoCompletedFields` or the `removeField` functions to remove the entire field instead of removing just `geolocationAutoCompleted` or `postalCodeAutoCompleted` flags. Both options would give a similar result, but modifying the latter could cause unexpected effects, since it's a change in the behaviour of the function, and some external app could be using it.

With that said, I decided to proceed with the approach of modifying the `removeAutoCompletedFields` function. Now, this function will remove not only the flag on the field but the entire field.

After this change, an AutoCompletedFields component test started to fail. This happened because the test was considering the remotion of just the flag, instead of the entire field. And as I said before this behaviour doesn't solve all the buggy cases.

https://github.com/vtex/address-form/pull/373/commits/0bad7bea62202204721fff3d9a1bb1b5c9869bde

This changes the logic of how to use the google address components to create an address. Now, different address fields can have equal values on `types` property. And, most importantly, it will respect the precedence of values present on `types` to choose the address component.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

This info was requested by the `veaargentina` account, and so, we are now adding it to the `ARG` address summary.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Add an item to cart](https://jeff--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2)
- Proceed to checkout
- Insert an email (It can be both first purchase or second purchase email)
- Move on to the shipping step
- Change the country to Argentina

**Case 1** (Address with neighborhood on `locality`)

- Use the address `Calle 3, 1350, San Clemente`
- Check that neighborhood `San Clemente del Tuyu` is shown.

**Case 2** (Address with neighborhood on `neighborhood`)

- Click on "Alterar"
- Use the address `Rioja 3950, Rosario, Santa Fe, Argentina`
- Check that neighborhood `Remedios de Escalada de San Martin` is shown.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/124140454-e04f3380-da5e-11eb-8639-a6a108a36c0e.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
