### PR TITLE
Fix geolocation autocomplete flag being lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `geolocationAutoCompleted` flag being lost after the address is validated.
+
 ## [3.16.13] - 2021-06-22
 
 ### Fixed

--- a/react/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
+++ b/react/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
@@ -43,6 +43,7 @@ Object {
   },
   "receiverName": Object {
     "focus": true,
+    "geolocationAutoCompleted": undefined,
     "reason": "ERROR_EMPTY_FIELD",
     "valid": false,
     "value": null,

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -29,10 +29,11 @@ export function isValidAddress(address, rules) {
 export function validateAddress(address, rules) {
   return reduce(
     address,
-    (memo, { value, valueOptions }, name) => {
+    (memo, { value, valueOptions, geolocationAutoCompleted }, name) => {
       memo[name] = {
         value,
         valueOptions,
+        geolocationAutoCompleted,
         ...validateField(value, name, address, rules),
       }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes a scenario where the `geolocationAutoCompleted` flag would be lost when the address was validated.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

This bug would cause the selector of city or state to be shown even when a given address was autocompleted by GMaps

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Add items to cart](https://jeff--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2)
- Proceed to checkout
- Use any email
- Move on to the shipping step
- Use the address `Castro Barros 523, córdoba, Argentina``
- Check that no city selector is shown
 
#### Screenshots or example usage

**Before**
![image](https://user-images.githubusercontent.com/12574426/124145103-e47d5000-da62-11eb-810a-6d9cdb4bee22.png)

**After**
![image](https://user-images.githubusercontent.com/12574426/124145241-0080f180-da63-11eb-8f06-630c27844fa1.png)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
