### PR TITLE
fix arg postal code general gutierrez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Address "General Gutierrez" mismatch for postal code based argentina stores.
 
 ## [3.18.1] - 2021-07-08
 

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -11062,7 +11062,7 @@ const countryData = {
     'Gaspar Campos',
     'General Acha',
     'General Alvear',
-    'General Gutiérrez',
+    'General Gutierrez',
     'General Ortega',
     'Germán Maturano',
     'Gertrudis De Ojeda',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix "General Gutierrez" naming in ARG based on the same name in postalcode service.

#### What problem is this solving?

The naming it's incorrect.

#### How should this be manually tested?

#### Screenshots or example usage

https://postalcode.vtexcommercestable.com.br/api/postal/pub/address/ARG/5511

The naming it's without "é"

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
