### PR TITLE
CHK-788, CHK-618: Fix receiverName not required and validation of number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `receiverName` not required for geolocation.
+- `number` fields required in geolocation but hidden in postal code.
+
 ## [3.18.1] - 2021-07-08
 
 ### Changed

--- a/react/country/ARE.js
+++ b/react/country/ARE.js
@@ -84,13 +84,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: false,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -102,13 +105,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['political', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21306,6 +21306,9 @@ export default {
         return address
       },
     },
+    receiverName: {
+      required: true,
+    },
   },
   summary: [
     [{ name: 'street' }, { delimiter: ' ', name: 'number' }],

--- a/react/country/BOL.js
+++ b/react/country/BOL.js
@@ -492,24 +492,33 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['locality', 'administrative_area_level_2'],
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['administrative_area_level_3'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/BRA.js
+++ b/react/country/BRA.js
@@ -118,16 +118,19 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -139,13 +142,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/CAN.js
+++ b/react/country/CAN.js
@@ -104,13 +104,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -122,13 +125,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/CHL.js
+++ b/react/country/CHL.js
@@ -546,13 +546,16 @@ export default {
         return address
       },
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -566,10 +569,16 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: { valueIn: 'short_name', types: ['administrative_area_level_1'] },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/COL.js
+++ b/react/country/COL.js
@@ -1309,12 +1309,14 @@ export default {
         return address
       },
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
@@ -1324,6 +1326,7 @@ export default {
         return address
       },
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -1336,6 +1339,7 @@ export default {
       ],
       required: false,
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
@@ -1347,6 +1351,7 @@ export default {
         return address
       },
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
@@ -1357,6 +1362,10 @@ export default {
 
         return address
       },
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/CRI.js
+++ b/react/country/CRI.js
@@ -790,16 +790,19 @@ export default {
         return address
       },
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -811,13 +814,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/DNK.js
+++ b/react/country/DNK.js
@@ -84,13 +84,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -102,13 +105,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/ECU.js
+++ b/react/country/ECU.js
@@ -695,13 +695,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -713,13 +716,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/ESP.js
+++ b/react/country/ESP.js
@@ -143,24 +143,33 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['neighborhood'],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/FIN.js
+++ b/react/country/FIN.js
@@ -84,13 +84,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -102,13 +105,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/FRA.js
+++ b/react/country/FRA.js
@@ -71,6 +71,7 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
@@ -80,13 +81,19 @@ export default {
         return address
       },
     },
+
     city: {
       valueIn: 'long_name',
       types: ['locality'],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/GBR.js
+++ b/react/country/GBR.js
@@ -86,6 +86,7 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route', 'street_address'],
@@ -95,6 +96,7 @@ export default {
         return address
       },
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -110,6 +112,7 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     complement: {
       valueIn: 'complement',
       types: [
@@ -121,13 +124,19 @@ export default {
         'subpremise',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['locality', 'administrative_area_level_2'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/GTM.js
+++ b/react/country/GTM.js
@@ -694,24 +694,33 @@ export default {
       types: ['postal_code'],
       required: true,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['neighborhood'],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/IND.js
+++ b/react/country/IND.js
@@ -84,13 +84,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -102,13 +105,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/ITA.js
+++ b/react/country/ITA.js
@@ -84,13 +84,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -102,13 +105,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_2'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_3', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/KOR.js
+++ b/react/country/KOR.js
@@ -87,6 +87,7 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
@@ -96,6 +97,7 @@ export default {
         return address
       },
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -107,13 +109,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/MEX.js
+++ b/react/country/MEX.js
@@ -122,27 +122,36 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['neighborhood'],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/NIC.js
+++ b/react/country/NIC.js
@@ -284,24 +284,33 @@ export default {
       types: ['postal_code'],
       required: true,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['neighborhood'],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/NIC.js
+++ b/react/country/NIC.js
@@ -282,7 +282,7 @@ export default {
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],
-      required: true,
+      required: false,
     },
 
     number: {

--- a/react/country/PER.js
+++ b/react/country/PER.js
@@ -2448,13 +2448,16 @@ export default {
         return address
       },
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: true,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['administrative_area_level_3', 'locality'],
@@ -2472,6 +2475,7 @@ export default {
         return address
       },
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
@@ -2507,6 +2511,7 @@ export default {
         return address
       },
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2'],
@@ -2517,6 +2522,10 @@ export default {
 
         return address
       },
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/PER.js
+++ b/react/country/PER.js
@@ -2424,7 +2424,7 @@ export default {
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],
-      required: true,
+      required: false,
       handler: (address) => {
         if (!address.state || !address.city || !address.neighborhood) {
           return address

--- a/react/country/PRT.js
+++ b/react/country/PRT.js
@@ -87,24 +87,33 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['neighborhood'],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/PRY.js
+++ b/react/country/PRY.js
@@ -444,11 +444,14 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
     },
+
     complement: {
       valueIn: 'long_name',
       types: ['street_number'],
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -460,13 +463,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/ROU.js
+++ b/react/country/ROU.js
@@ -14052,6 +14052,9 @@ export default {
       valueIn: 'long_name',
       types: ['administrative_area_level_3'],
     },
+    receiverName: {
+      required: true,
+    },
   },
   summary: [
     [

--- a/react/country/RUS.js
+++ b/react/country/RUS.js
@@ -363,13 +363,16 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
@@ -395,13 +398,19 @@ export default {
         return address
       },
     },
+
     city: {
       valueIn: 'long_name',
       types: ['locality', 'administrative_area_level_2'],
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['administrative_area_level_3'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/SLV.js
+++ b/react/country/SLV.js
@@ -386,7 +386,7 @@ export default {
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],
-      required: true,
+      required: false,
     },
 
     number: {

--- a/react/country/SLV.js
+++ b/react/country/SLV.js
@@ -388,24 +388,33 @@ export default {
       types: ['postal_code'],
       required: true,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: ['neighborhood'],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/SMR.js
+++ b/react/country/SMR.js
@@ -82,13 +82,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -100,13 +103,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/SWE.js
+++ b/react/country/SWE.js
@@ -84,13 +84,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -102,13 +105,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/URY.js
+++ b/react/country/URY.js
@@ -427,12 +427,15 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -444,13 +447,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/USA.js
+++ b/react/country/USA.js
@@ -151,6 +151,7 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
@@ -160,6 +161,7 @@ export default {
         return address
       },
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -171,13 +173,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/VEN.js
+++ b/react/country/VEN.js
@@ -291,11 +291,14 @@ export default {
       valueIn: 'long_name',
       types: ['postal_code'],
     },
+
     complement: {
       valueIn: 'long_name',
       types: ['street_number'],
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -308,13 +311,19 @@ export default {
       ],
       required: false,
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/__mocks__/useOneLevel.js
+++ b/react/country/__mocks__/useOneLevel.js
@@ -97,6 +97,7 @@ export default {
         return address
       },
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
@@ -109,16 +110,23 @@ export default {
         }
       },
     },
+
     street: { valueIn: 'long_name', types: ['route'], required: false },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
       required: false,
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
       required: false,
+    },
+
+    receiverName: {
+      required: true,
     },
   },
 }

--- a/react/country/__mocks__/usePostalCode.js
+++ b/react/country/__mocks__/usePostalCode.js
@@ -78,6 +78,7 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
@@ -90,11 +91,13 @@ export default {
         }
       },
     },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],
       required: false,
     },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -107,15 +110,21 @@ export default {
       ],
       required: false,
     },
+
     state: {
       valueIn: 'short_name',
       types: ['administrative_area_level_1'],
       required: false,
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
       required: false,
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -83,13 +83,16 @@ export default {
       types: ['postal_code'],
       required: false,
     },
+
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
       required: false,
       notApplicable: true,
     },
+
     street: { valueIn: 'long_name', types: ['route'] },
+
     neighborhood: {
       valueIn: 'long_name',
       types: [
@@ -101,13 +104,19 @@ export default {
         'sublocality_level_5',
       ],
     },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],
     },
+
     city: {
       valueIn: 'long_name',
       types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
     },
   },
   summary: [

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -130,7 +130,7 @@ export default function geolocationAutoCompleteAddress(
 }
 
 function getAddressComponent(addressComponents, types) {
-  for (const type of types) {
+  for (const type of types ?? []) {
     const addressComponent = addressComponents.find((component) =>
       component.types.includes(type)
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

These changes add the `receiverName` to the geolocation rules of all countries 
and mark it as required. This also updates the number field in the geolocation 
rules for the countries that have it hidden in the postal code rules to not 
mark it as required.

#### What problem is this solving?

Fixes user being able to proceed to payment with an invalid address, and users 
not able to go to payment due to the missing number in the auto completed 
address.

#### How should this be manually tested?

[Workspace in lopidocolombia](https://lucas--lopidocolombia.myvtex.com/checkout/cart/add/?sku=5157&qty=1&seller=1&sc=2)

[Workspace in vtexgame1geo](https://lucas--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&sc=2)

[Workspace in tottoelsalvador](https://tottoelsalvador.myvtex.com/checkout/?workspace=lucas#/cart)

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
