### PR TITLE
Add 'GeolocationInput' to exported 'components'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `GeolocationInput` to exported `components`.
+
 ## [4.7.5] - 2021-06-22
 
 ### Fixed

--- a/react/components.js
+++ b/react/components.js
@@ -8,6 +8,7 @@ import AddressRules from './AddressRules'
 import AddressSubmitter from './AddressSubmitter'
 import PostalCodeLoader from './postalCodeFrom/PostalCodeLoader'
 import GoogleMapsContainer from './geolocation/GoogleMapsContainer'
+import GeolocationInput from './geolocation/GeolocationInput'
 import Map from './geolocation/Map'
 import StyleguideInput from './inputs/StyleguideInput'
 import StyleguideButton from './inputs/StyleguideButton'
@@ -21,6 +22,7 @@ export default {
   AutoCompletedFields,
   CountrySelector,
   GoogleMapsContainer,
+  GeolocationInput,
   Map,
   PostalCodeGetter,
   PostalCodeLoader,


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, add to exported components file to use in VTEX IO.

#### What problem is this solving?

The component could not be used by importing `vtex.address-form` via VTEX IO.

#### How should this be manually tested?

[Workspace with the component working](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/). **Still testing the layout and AddressForm viability.**

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/125662737-f712b642-97cc-4359-832e-2eb8b82c790d.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
