### PR TITLE
Revert/autocomplete change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Change of address autocompleted by postal code.
 
 ## [3.18.4] - 2021-07-13
 ### Fixed

--- a/react/AutoCompletedFields.js
+++ b/react/AutoCompletedFields.js
@@ -1,24 +1,21 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import pickBy from 'lodash/pickBy'
+import flow from 'lodash/flow'
 import { compose } from 'recompose'
 
 import AddressShapeWithValidation from './propTypes/AddressShapeWithValidation'
 import AddressSummary from './AddressSummary'
-import { removeValidation } from './transforms/address'
+import { removeValidation, removeField } from './transforms/address'
 import { injectRules } from './addressRulesContext'
 import { injectAddressContext } from './addressContainerContext'
 
 const IRRELEVANT_FIELDS = ['country', 'geoCoordinates']
 
-const removeAutoCompletedFields = (address) => {
-  const addressFieldsNotAutoCompleted = Object.entries(address).filter(
-    ([_, value]) =>
-      !value.geolocationAutoCompleted && !value.postalCodeAutoCompleted
-  )
-
-  return Object.fromEntries(addressFieldsNotAutoCompleted)
-}
+const removeAutoCompletedFields = flow([
+  (address) => removeField(address, 'postalCodeAutoCompleted'),
+  (address) => removeField(address, 'geolocationAutoCompleted'),
+])
 
 class AutoCompletedFields extends Component {
   handleClickChange = (e) => {

--- a/react/AutoCompletedFields.test.js
+++ b/react/AutoCompletedFields.test.js
@@ -117,8 +117,7 @@ describe('AutoCompletedFields', () => {
         'postalCodeAutoCompleted',
         undefined
       )
-      expect(onChangeAddressArgument.city).toBeFalsy()
-      expect(onChangeAddressArgument.neighborhood).toBeFalsy()
+      expect(onChangeAddressArgument.city).toHaveProperty('value', city)
     })
 
     it('should not display country information', () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR reverts the changes made by https://github.com/vtex/address-form/pull/373/commits/c87994374ce4a0349413f0de283581e79deec070 of https://github.com/vtex/address-form/pull/373

This is needed because this change introduced a bug that prevents the user from changing an address that was autocompleted by postal code.

<!--- Describe your changes in detail. -->

#### How should this be manually tested?

- [Add an item to cart](https://jeff--vtexgame1.myvtex.com/checkout/cart/add/?sku=289&qty=1&seller=1&sc=1)
- Proceed to checkout
- Fill in profile info
- On the shipping step, use the postal code `22230001` 
- Try to change the address by clicking on "Cambiar"
- You should be able to change your address

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
