### PR TITLE
[LOGB2C-825] Fix StyleguideInput evaluation on hidden fields rules and postal code padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Postal code `form` lack of padding.
+- `StyleguideInput` ignoring `hidden` rules in non-default fields.
+
 ## [4.7.5] - 2021-06-22
 
 ### Fixed

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -97,7 +97,9 @@ class StyleguideInput extends Component {
     if (field.name === 'postalCode') {
       return (
         <form
-          className="vtex-address-form__postalCode"
+          className={`vtex-address-form__postalCode ${
+            field.hidden ? 'dn' : ''
+          } pb7`}
           onSubmit={this.handleSubmit}
         >
           {Button ? (
@@ -129,7 +131,11 @@ class StyleguideInput extends Component {
 
     if (field.name === 'addressQuery') {
       return (
-        <div className="vtex-address-form__addressQuery flex flex-row pb7">
+        <div
+          className={`vtex-address-form__addressQuery ${
+            field.hidden ? 'dn' : ''
+          } flex flex-row pb7`}
+        >
           <Input
             label={
               field.fixedLabel ||
@@ -166,7 +172,11 @@ class StyleguideInput extends Component {
       (field.notApplicable || address['addressQuery'].geolocationAutoCompleted)
     ) {
       return (
-        <div className="vtex-address-form__number-div flex flex-row pb7">
+        <div
+          className={`vtex-address-form__number-div ${
+            field.hidden ? 'dn' : ''
+          } flex flex-row pb7`}
+        >
           <div className="vtex-address-form__number-input flex w-50">
             <Input
               label={
@@ -212,7 +222,11 @@ class StyleguideInput extends Component {
 
     if (options) {
       return (
-        <div className={`vtex-address-form__${field.name} pb6`}>
+        <div
+          className={`vtex-address-form__${field.name} ${
+            field.hidden ? 'dn' : ''
+          } pb6`}
+        >
           <Dropdown
             options={options}
             value={address[field.name].value || ''}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the `StyleguideInput` was not considering `hidden` fields rules when the field was not a non-default field, such as `postalCode`, for example. Also, the `postalCode` `form` had no padding.

#### How should this be manually tested?

[Workspace](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/).

#### Screenshots or example usage

##### Before

![image](https://user-images.githubusercontent.com/15948386/125833388-669abf37-a9c2-43b2-8c52-681cae0be299.png)

[Bolivia, which should have postalCode field hidden](https://github.com/vtex/address-form/blob/4.x/react/country/BOL.js#L416).

![image](https://user-images.githubusercontent.com/15948386/125833433-8fd07b60-45c0-4579-8960-7bbe24a68f0f.png)

##### After

![image](https://user-images.githubusercontent.com/15948386/125834083-e41846b9-0d60-4a60-9175-c7949ed30270.png)

Now, Bolivia doesn't show the field.

![image](https://user-images.githubusercontent.com/15948386/125834181-86e2e2ae-3943-47be-8f9e-3a1da2acc7aa.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
