### PR TITLE
CHK-826, CHK-831: consistency of neighborhood/reference fields 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Fixed
 - Address fields being overwritten with old information on geolocation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Address fields being overwritten with old information on geolocation.
+
 ## [3.18.5] - 2021-07-15
 ### Fixed
 - Change of address autocompleted by postal code.

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21269,7 +21269,6 @@ export default {
         'sublocality_level_3',
         'sublocality_level_4',
         'sublocality_level_5',
-        'locality',
       ],
     },
     state: {

--- a/react/country/ARG.js
+++ b/react/country/ARG.js
@@ -21269,6 +21269,7 @@ export default {
         'sublocality_level_3',
         'sublocality_level_4',
         'sublocality_level_5',
+        'locality',
       ],
     },
     state: {

--- a/react/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
+++ b/react/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
@@ -16,6 +16,10 @@ Object {
     "geolocationAutoCompleted": true,
     "value": "Rio de Janeiro",
   },
+  "complement": Object {
+    "geolocationAutoCompleted": true,
+    "value": null,
+  },
   "country": Object {
     "geolocationAutoCompleted": true,
     "value": "BRA",
@@ -48,6 +52,10 @@ Object {
     "valid": false,
     "value": null,
     "valueOptions": undefined,
+  },
+  "reference": Object {
+    "geolocationAutoCompleted": true,
+    "value": null,
   },
   "state": Object {
     "geolocationAutoCompleted": true,

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -1,7 +1,7 @@
 import flow from 'lodash/flow'
 
 import getCountryISO2 from '../countryISOMap'
-import { addNewField, addFocusToNextInvalidField } from '../transforms/address'
+import { addNewField, addFocusToNextInvalidField, createNewAddress } from '../transforms/address'
 
 export default function geolocationAutoCompleteAddress(
   baseAddress,
@@ -56,7 +56,7 @@ export default function geolocationAutoCompleteAddress(
 
         return updatedAddress
       },
-      {}
+      createNewAddress()
     )
   }
 

--- a/react/geolocation/geolocationAutoCompleteAddress.test.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.test.js
@@ -60,7 +60,7 @@ describe('Geolocation Auto Complete Address', () => {
     expect(address.receiverName.value).toBe(receiverName)
   })
 
-  it('should remove fields that are not auto completed', () => {
+  it('should empty fields that are not auto completed', () => {
     const complement = 'apt 505'
 
     const address = geolocationAutoCompleteAddress(
@@ -72,7 +72,7 @@ describe('Geolocation Auto Complete Address', () => {
       usePostalCode
     )
 
-    expect(address.complement).toBeUndefined()
+    expect(address.complement.value).toBeNull()
   })
 
   it('should keep number as notApplicable', () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the issue of the neighborhood/reference fields being filled with previous information. 

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Open [here](https://ref--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&seller=1&qty=1&sc=2).
Fill the personal info.
Fill the shipping info with the address Rioja 3950, Rosario Santa Fe.
Then, change the address to Calle 3 1350, San Clemente del Tuyu, Provincia de Buenos Aires, Argentina.
Check that after changing the address the `address.neighborhood` field is null in the orderform.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
