### PR TITLE
[LOGB2C-822] Fix StyleguideInput not using addressQuery value when initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Postal code `form` lack of padding.
 - `StyleguideInput` ignoring `hidden` rules in non-default fields.
+- `StyleguideInput` not using `addressQuery` value when initialized.
 
 ## [4.7.5] - 2021-06-22
 

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -162,6 +162,7 @@ class StyleguideInput extends Component {
             error={!this.state.isInputValid}
             ref={inputRef}
             suffix={<SpinnerLoading isLoading={loading} />}
+            value={address[field.name].value || ''}
           />
         </div>
       )


### PR DESCRIPTION
✅  This PR can be merged so we do a single release in #385

#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

When initialized, the field was ignoring the `addressQuery` value. So the field was always empty, even when shouldn't be.

#### How should this be manually tested?

[Workspace with the fix](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/?id=teste-endereco).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/126554898-ba9aaabd-ce15-4729-82bf-56aac175ad48.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
