### PR TITLE
[LOGB2C-841] Enhance styling possibilities when using AddressForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `StyleguideInput` field size classes, allowing generic CSS styling.
+- `omitContainerElement` prop to enhance CSS styling in `AddressForm` and `PostalCodeGetter`.
+
+### Removed
+
+- `StyleguideInput` number field wrong placeholder.
+
 ## [4.7.6] - 2021-07-27
 
 ### Fixed

--- a/react/AddressForm.js
+++ b/react/AddressForm.js
@@ -25,6 +25,7 @@ class AddressForm extends Component {
       notApplicableLabel,
       omitPostalCodeFields,
       omitAutoCompletedFields,
+      omitContainerElement,
     } = this.props
 
     let fields = omitPostalCodeFields
@@ -35,30 +36,31 @@ class AddressForm extends Component {
       ? filterAutoCompletedFields({ fields }, address)
       : fields
 
-    return (
-      <div>
-        {fields.map(field =>
-          isDefiningPostalCodeField(field.name, rules) ? (
-            <SelectPostalCode
-              Input={Input}
-              rules={rules}
-              address={address}
-              onChangeAddress={onChangeAddress}
-            />
-          ) : (
-            <InputFieldContainer
-              intl={intl}
-              key={field.name}
-              Input={Input}
-              field={field}
-              address={address}
-              rules={rules}
-              onChangeAddress={onChangeAddress}
-              notApplicableLabel={notApplicableLabel}
-            />
-          ),
-        )}
-      </div>
+    const content = fields.map((field) =>
+      isDefiningPostalCodeField(field.name, rules) ? (
+        <SelectPostalCode
+          Input={Input}
+          rules={rules}
+          address={address}
+          onChangeAddress={onChangeAddress}
+        />
+      ) : (
+        <InputFieldContainer
+          intl={intl}
+          key={field.name}
+          Input={Input}
+          field={field}
+          address={address}
+          rules={rules}
+          onChangeAddress={onChangeAddress}
+          notApplicableLabel={notApplicableLabel}
+        />
+      ),
+    )
+    return omitContainerElement ? (
+      content
+    ) : (
+      <div className="vtex-address-form__container">{content}</div>
     )
   }
 }
@@ -66,6 +68,7 @@ class AddressForm extends Component {
 AddressForm.defaultProps = {
   omitPostalCodeFields: true,
   omitAutoCompletedFields: true,
+  omitContainerElement: false,
   Input: DefaultInput,
 }
 
@@ -80,9 +83,5 @@ AddressForm.propTypes = {
   notApplicableLabel: PropTypes.string,
 }
 
-const enhance = compose(
-  injectAddressContext,
-  injectRules,
-  injectIntl,
-)
+const enhance = compose(injectAddressContext, injectRules, injectIntl)
 export default enhance(AddressForm)

--- a/react/AddressForm.js
+++ b/react/AddressForm.js
@@ -39,6 +39,7 @@ class AddressForm extends Component {
     const content = fields.map((field) =>
       isDefiningPostalCodeField(field.name, rules) ? (
         <SelectPostalCode
+          key={field.name}
           Input={Input}
           rules={rules}
           address={address}

--- a/react/PostalCodeGetter.js
+++ b/react/PostalCodeGetter.js
@@ -28,6 +28,7 @@ class PostalCodeGetter extends Component {
       intl,
       onSubmit,
       submitLabel,
+      omitContainerElement,
     } = this.props
 
     switch (rules.postalCodeFrom) {
@@ -41,6 +42,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            omitContainerElement={omitContainerElement}
             onSubmit={onSubmit}
             submitLabel={submitLabel}
           />
@@ -55,6 +57,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            omitContainerElement={omitContainerElement}
             onSubmit={onSubmit}
             submitLabel={submitLabel}
           />
@@ -69,6 +72,7 @@ class PostalCodeGetter extends Component {
             address={address}
             rules={rules}
             onChangeAddress={onChangeAddress}
+            omitContainerElement={omitContainerElement}
             onSubmit={onSubmit}
             submitLabel={submitLabel}
           />
@@ -103,6 +107,7 @@ PostalCodeGetter.defaultProps = {
   loading: false,
   Input: DefaultInput,
   shouldShowNumberKeyboard: false,
+  omitContainerElement: false,
 }
 
 PostalCodeGetter.propTypes = {
@@ -117,6 +122,7 @@ PostalCodeGetter.propTypes = {
   rules: PropTypes.object.isRequired,
   shouldShowNumberKeyboard: PropTypes.bool,
   submitLabel: PropTypes.string,
+  omitContainerElement: PropTypes.bool,
 }
 
 const enhance = compose(injectAddressContext, injectRules, injectIntl)

--- a/react/__snapshots__/AddressForm.test.js.snap
+++ b/react/__snapshots__/AddressForm.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AddressForm should omit fields that are used in to get the postal code 1`] = `
-<div>
+<div
+  className="vtex-address-form__container"
+>
   <p
     className="input ship-street required text"
   >

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -96,7 +96,7 @@ class StyleguideInput extends Component {
 
     const commonClassNames = `vtex-address-form__${
       field.name
-    } vtex-address-form__field--${field.size ?? 'xlarge'} ${field.hidden ? 'dn' : ''}`
+    } vtex-address-form__field--${field.size || 'xlarge'} ${field.hidden ? 'dn' : ''}`
 
     if (field.name === 'postalCode') {
       return (

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -94,12 +94,14 @@ class StyleguideInput extends Component {
       type,
     }
 
+    const commonClassNames = `vtex-address-form__${
+      field.name
+    } vtex-address-form__field--${field.size ?? 'xlarge'} ${field.hidden ? 'dn' : ''}`
+
     if (field.name === 'postalCode') {
       return (
         <form
-          className={`vtex-address-form__postalCode ${
-            field.hidden ? 'dn' : ''
-          } pb7`}
+          className={`${commonClassNames} pb7`}
           onSubmit={this.handleSubmit}
         >
           {Button ? (
@@ -117,7 +119,7 @@ class StyleguideInput extends Component {
           )}
 
           {field.forgottenURL && (
-            <div className="pt4 flex-none">
+            <div className="vtex-address-form__postalCode-forgottenURL pt4 flex-none">
               <Link href={field.forgottenURL} target="_blank">
                 {intl.formatMessage({
                   id: 'address-form.dontKnowPostalCode',
@@ -131,11 +133,7 @@ class StyleguideInput extends Component {
 
     if (field.name === 'addressQuery') {
       return (
-        <div
-          className={`vtex-address-form__addressQuery ${
-            field.hidden ? 'dn' : ''
-          } flex flex-row pb7`}
-        >
+        <div className={`${commonClassNames} flex flex-row pb7`}>
           <Input
             label={
               field.fixedLabel ||
@@ -174,9 +172,7 @@ class StyleguideInput extends Component {
     ) {
       return (
         <div
-          className={`vtex-address-form__number-div ${
-            field.hidden ? 'dn' : ''
-          } flex flex-row pb7`}
+          className={`vtex-address-form__number-div ${commonClassNames} flex flex-row pb7`}
         >
           <div className="vtex-address-form__number-input flex w-50">
             <Input
@@ -191,12 +187,6 @@ class StyleguideInput extends Component {
                     })
                   : undefined
               }
-              placeholder={intl.formatMessage({
-                id: `address-form.geolocation.example.${address.country.value}`,
-                defaultMessage: intl.formatMessage({
-                  id: 'address-form.geolocation.example.UNI',
-                }),
-              })}
               autoFocus={autoFocus}
               onChange={this.handleChange}
               onBlur={this.handleBlur}
@@ -223,11 +213,7 @@ class StyleguideInput extends Component {
 
     if (options) {
       return (
-        <div
-          className={`vtex-address-form__${field.name} ${
-            field.hidden ? 'dn' : ''
-          } pb6`}
-        >
+        <div className={`${commonClassNames} pb6`}>
           <Dropdown
             options={options}
             value={address[field.name].value || ''}
@@ -244,11 +230,7 @@ class StyleguideInput extends Component {
     }
 
     return (
-      <div
-        className={`vtex-address-form__${field.name} ${
-          field.hidden ? 'dn' : ''
-        } pb7`}
-      >
+      <div className={`${commonClassNames} pb7`}>
         <Input
           label={this.props.intl.formatMessage({
             id: `address-form.field.${field.label}`,

--- a/react/postalCodeFrom/OneLevel.js
+++ b/react/postalCodeFrom/OneLevel.js
@@ -5,7 +5,7 @@ import SelectPostalCode from './SelectPostalCode'
 import SubmitButton from './SubmitButton'
 
 class OneLevel extends Component {
-  handleSubmit = event => {
+  handleSubmit = (event) => {
     event.preventDefault()
     this.props.onSubmit && this.props.onSubmit()
   }
@@ -18,6 +18,7 @@ class OneLevel extends Component {
       loading,
       onSubmit,
       onChangeAddress,
+      omitContainerElement,
       rules,
       submitLabel,
     } = this.props
@@ -39,18 +40,23 @@ class OneLevel extends Component {
         </form>
       )
     }
-    return (
-      <div>
-        <SelectPostalCode
-          address={address}
-          Input={Input}
-          loading={loading}
-          rules={rules}
-          onChangeAddress={onChangeAddress}
-        />
-      </div>
+
+    const content = (
+      <SelectPostalCode
+        address={address}
+        Input={Input}
+        loading={loading}
+        rules={rules}
+        onChangeAddress={onChangeAddress}
+      />
     )
+
+    return omitContainerElement ? content : <div>{content}</div>
   }
+}
+
+OneLevel.defaultProps = {
+  omitContainerElement: false,
 }
 
 OneLevel.propTypes = {
@@ -60,6 +66,7 @@ OneLevel.propTypes = {
   Input: PropTypes.func.isRequired,
   rules: PropTypes.object.isRequired,
   onChangeAddress: PropTypes.func.isRequired,
+  omitContainerElement: PropTypes.bool,
   onSubmit: PropTypes.func,
   submitLabel: PropTypes.string,
 }

--- a/react/postalCodeFrom/ThreeLevels.js
+++ b/react/postalCodeFrom/ThreeLevels.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import AddressShapeWithValidation from '../propTypes/AddressShapeWithValidation'
 import SelectLevel from './SelectLevel'
@@ -59,7 +59,7 @@ class ThreeLevels extends Component {
     }
 
     const content = (
-      <>
+      <Fragment>
         <SelectLevel
           level={0}
           Input={Input}
@@ -83,7 +83,7 @@ class ThreeLevels extends Component {
           address={address}
           onChangeAddress={onChangeAddress}
         />
-      </>
+      </Fragment>
     )
 
     return omitContainerElement ? content : <div>{content}</div>

--- a/react/postalCodeFrom/ThreeLevels.js
+++ b/react/postalCodeFrom/ThreeLevels.js
@@ -6,7 +6,7 @@ import SelectPostalCode from './SelectPostalCode'
 import SubmitButton from './SubmitButton'
 
 class ThreeLevels extends Component {
-  handleSubmit = event => {
+  handleSubmit = (event) => {
     event.preventDefault()
     this.props.onSubmit && this.props.onSubmit()
   }
@@ -19,6 +19,7 @@ class ThreeLevels extends Component {
       Input,
       loading,
       onChangeAddress,
+      omitContainerElement,
       onSubmit,
       submitLabel,
     } = this.props
@@ -57,8 +58,8 @@ class ThreeLevels extends Component {
       )
     }
 
-    return (
-      <div>
+    const content = (
+      <>
         <SelectLevel
           level={0}
           Input={Input}
@@ -82,9 +83,15 @@ class ThreeLevels extends Component {
           address={address}
           onChangeAddress={onChangeAddress}
         />
-      </div>
+      </>
     )
+
+    return omitContainerElement ? content : <div>{content}</div>
   }
+}
+
+ThreeLevels.defaultProps = {
+  omitContainerElement: false,
 }
 
 ThreeLevels.propTypes = {
@@ -96,6 +103,7 @@ ThreeLevels.propTypes = {
   onSubmit: PropTypes.func,
   rules: PropTypes.object.isRequired,
   submitLabel: PropTypes.string,
+  omitContainerElement: PropTypes.bool,
 }
 
 export default ThreeLevels

--- a/react/postalCodeFrom/TwoLevels.js
+++ b/react/postalCodeFrom/TwoLevels.js
@@ -6,7 +6,7 @@ import SelectPostalCode from './SelectPostalCode'
 import SubmitButton from './SubmitButton'
 
 class TwoLevels extends Component {
-  handleSubmit = event => {
+  handleSubmit = (event) => {
     event.preventDefault()
     this.props.onSubmit && this.props.onSubmit()
   }
@@ -18,6 +18,7 @@ class TwoLevels extends Component {
       Input,
       loading,
       onChangeAddress,
+      omitContainerElement,
       onSubmit,
       submitLabel,
       Button,
@@ -49,8 +50,8 @@ class TwoLevels extends Component {
       )
     }
 
-    return (
-      <div>
+    const content = (
+      <>
         <SelectLevel
           level={0}
           Input={Input}
@@ -66,9 +67,15 @@ class TwoLevels extends Component {
           address={address}
           onChangeAddress={onChangeAddress}
         />
-      </div>
+      </>
     )
+
+    return omitContainerElement ? content : <div>{content}</div>
   }
+}
+
+TwoLevels.defaultProps = {
+  omitContainerElement: false,
 }
 
 TwoLevels.propTypes = {
@@ -80,6 +87,7 @@ TwoLevels.propTypes = {
   onSubmit: PropTypes.func,
   rules: PropTypes.object.isRequired,
   submitLabel: PropTypes.string,
+  omitContainerElement: PropTypes.bool,
 }
 
 export default TwoLevels

--- a/react/postalCodeFrom/TwoLevels.js
+++ b/react/postalCodeFrom/TwoLevels.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Fragment, Component } from 'react'
 import PropTypes from 'prop-types'
 import AddressShapeWithValidation from '../propTypes/AddressShapeWithValidation'
 import SelectLevel from './SelectLevel'
@@ -51,7 +51,7 @@ class TwoLevels extends Component {
     }
 
     const content = (
-      <>
+      <Fragment>
         <SelectLevel
           level={0}
           Input={Input}
@@ -67,7 +67,7 @@ class TwoLevels extends Component {
           address={address}
           onChangeAddress={onChangeAddress}
         />
-      </>
+      </Fragment>
     )
 
     return omitContainerElement ? content : <div>{content}</div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

The idea is to enhance the extensibility of the library by adding CSS classes to allow generic styling independently from the country and the possibility to omit some of the container elements added by the AddressForm.

Also, in this PR a wrong placeholder in the "Number" field is removed.

#### How should this be manually tested?

[Workspace](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/127538483-01bb5c22-820d-4070-a884-26971c45abe3.png)

![image](https://user-images.githubusercontent.com/15948386/127538529-bd773ab8-6cec-427d-86b6-8bf084c26d68.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
