### PR TITLE
[LOGB2C-845] Add GeolocationInput optional autocompleteOptions prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `GeolocationInput` optional `autocompleteOptions` prop.
+
 ## [4.8.0] - 2021-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `GeolocationInput` optional `autocompleteOptions` prop.
+- `loadingRules`, `rulesError` and `fetchRules` to `AddressRulesContext` to enhance UX possibilities.
+- `AddressRules` optional `useDefaultRulesAsFallback` prop.
 
 ## [4.8.0] - 2021-08-03
 

--- a/react/addressRulesContext.js
+++ b/react/addressRulesContext.js
@@ -9,7 +9,15 @@ export function injectRules(Component) {
 
     return (
       <RulesContext.Consumer>
-        {rules => <Component {...props} rules={rules} />}
+        {({ rules, loadingRules, rulesError, fetchRules } = {}) => (
+          <Component
+            {...props}
+            rules={rules}
+            loadingRules={loadingRules}
+            rulesError={rulesError}
+            fetchRules={fetchRules}
+          />
+        )}
       </RulesContext.Consumer>
     )
   }

--- a/react/geolocation/GeolocationInput.js
+++ b/react/geolocation/GeolocationInput.js
@@ -38,16 +38,18 @@ class GeolocationInput extends Component {
 
     this.input = input
 
-    const options =
-      autocompleteOptions ||
-      (rules.abbr
-        ? {
-            types: ['address'],
-            componentRestrictions: {
-              country: rules.abbr,
-            },
-          }
-        : { types: ['address'] })
+    const options = rules.abbr
+      ? {
+          types: ['address'],
+          componentRestrictions: {
+            country: rules.abbr,
+            ...((autocompleteOptions &&
+              autocompleteOptions.componentRestrictions) ||
+              {}),
+          },
+          ...autocompleteOptions,
+        }
+      : { types: ['address'], ...autocompleteOptions }
 
     if (useSearchBox) {
       this.autocomplete = new googleMaps.places.SearchBox(this.input)

--- a/react/geolocation/GeolocationInput.js
+++ b/react/geolocation/GeolocationInput.js
@@ -27,7 +27,7 @@ class GeolocationInput extends Component {
   }
 
   handleMountInput = input => {
-    const { useSearchBox, rules, googleMaps } = this.props
+    const { useSearchBox, rules, googleMaps, autocompleteOptions } = this.props
 
     if (!input) {
       this.input = null
@@ -38,14 +38,16 @@ class GeolocationInput extends Component {
 
     this.input = input
 
-    const options = rules.abbr
-      ? {
-        types: ['address'],
-        componentRestrictions: {
-          country: rules.abbr,
-        },
-      }
-      : { types: ['address'] }
+    const options =
+      autocompleteOptions ||
+      (rules.abbr
+        ? {
+            types: ['address'],
+            componentRestrictions: {
+              country: rules.abbr,
+            },
+          }
+        : { types: ['address'] })
 
     if (useSearchBox) {
       this.autocomplete = new googleMaps.places.SearchBox(this.input)
@@ -192,6 +194,8 @@ GeolocationInput.propTypes = {
   loadingGoogle: PropTypes.bool,
   autoFocus: PropTypes.bool,
   googleMaps: PropTypes.object,
+  // See: https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions
+  autocompleteOptions: PropTypes.object,
 }
 
 const enhance = compose(


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the idea is to give more flexibility when using `GeolocationInput` component.

#### What problem is this solving?

There's no way of using other Google autocomplete options in this component, such as only showing until the city level address.

#### How should this be manually tested?

[Workspace](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/129035040-464cd0de-81b9-4853-bb5e-9809bff0b7c9.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
