### PR TITLE
Change CEP Forgotten URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Forgotten URL for CEP in Brazil
+
 ## [3.18.7] - 2021-07-29
 ### Fixed
 - Address fields being overwritten with old information on geolocation.

--- a/react/country/BRA.js
+++ b/react/country/BRA.js
@@ -21,7 +21,7 @@ export default {
       mask: '99999-999',
       regex: '^([\\d]{5})\\-?([\\d]{3})$',
       postalCodeAPI: true,
-      forgottenURL: '//buscacepinter.correios.com.br',
+      forgottenURL: '//buscacepinter.correios.com.br/app/endereco/index.php?t',
       size: 'small',
       autoComplete: 'nope',
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
As the title says.

#### What problem is this solving?
The previous link is quite unstable according to this [task](https://vtex-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=411&modal=detail&selectedIssue=CTP-3501&assignee=5e1723dd62aed90daa496a26) so it was replaced by a new and more stable one.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

You can test it by using the [workspace](https://fixcepcheckout--gatewayqa.myvtex.com/checkout/#/shipping)

#### Screenshots or example usage

Before
<img width="707" alt="Screen Shot 2021-08-11 at 4 01 36 PM" src="https://user-images.githubusercontent.com/9946330/129087658-7406f6f1-bb62-408c-9d9d-6c3667624c66.png">


After
<img width="699" alt="Screen Shot 2021-08-11 at 4 00 57 PM" src="https://user-images.githubusercontent.com/9946330/129087610-b1ea97f0-0571-4281-973c-f6f96132862e.png">


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
