### PR TITLE
[LOGB2C-828] Add loadingRules to AddressRulesContext to enhance UX possibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `GeolocationInput` optional `autocompleteOptions` prop.
+- `loadingRules` to `AddressRulesContext` to enhance UX possibilities.
 
 ## [4.8.0] - 2021-08-03
 

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -12,6 +12,7 @@ class AddressRules extends Component {
     this.state = {
       country: null,
       rules: null,
+      loading: false,
     }
   }
 
@@ -35,6 +36,7 @@ class AddressRules extends Component {
   }
 
   fetchRules(rulePromise) {
+    this.setState({ loading: true })
     return rulePromise
       .then(ruleData => ruleData.default || ruleData)
       .catch(error => {
@@ -51,6 +53,8 @@ class AddressRules extends Component {
         if (process.env.NODE_ENV !== 'production') {
           console.error('An unknown error occurred.', error)
         }
+      }).finally(() => {
+        this.setState({ loading: false })
       })
   }
 
@@ -89,12 +93,12 @@ class AddressRules extends Component {
 
   render() {
     const { children } = this.props
-    const { rules } = this.state
+    const { rules, loading } = this.state
 
     if (!rules) return null
 
     return (
-      <RulesContext.Provider value={rules}>{children}</RulesContext.Provider>
+      <RulesContext.Provider value={{ rules, loading }}>{children}</RulesContext.Provider>
     )
   }
 }

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -12,7 +12,7 @@ class AddressRules extends Component {
     this.state = {
       country: null,
       rules: null,
-      loading: false,
+      loadingRules: false,
     }
   }
 
@@ -36,7 +36,7 @@ class AddressRules extends Component {
   }
 
   fetchRules(rulePromise) {
-    this.setState({ loading: true })
+    this.setState({ loadingRules: true })
     return rulePromise
       .then(ruleData => ruleData.default || ruleData)
       .catch(error => {
@@ -54,7 +54,7 @@ class AddressRules extends Component {
           console.error('An unknown error occurred.', error)
         }
       }).finally(() => {
-        this.setState({ loading: false })
+        this.setState({ loadingRules: false })
       })
   }
 
@@ -93,12 +93,12 @@ class AddressRules extends Component {
 
   render() {
     const { children } = this.props
-    const { rules, loading } = this.state
+    const { rules, loadingRules } = this.state
 
     if (!rules) return null
 
     return (
-      <RulesContext.Provider value={{ rules, loading }}>{children}</RulesContext.Provider>
+      <RulesContext.Provider value={{ rules, loadingRules }}>{children}</RulesContext.Provider>
     )
   }
 }

--- a/react/addressRulesContext.js
+++ b/react/addressRulesContext.js
@@ -9,7 +9,7 @@ export function injectRules(Component) {
 
     return (
       <RulesContext.Consumer>
-        {({ rules, loading } = {}) => <Component {...props} rules={rules} loadingRules={loading} />}
+        {({ rules, loadingRules } = {}) => <Component {...props} rules={rules} loadingRules={loadingRules} />}
       </RulesContext.Consumer>
     )
   }

--- a/react/addressRulesContext.js
+++ b/react/addressRulesContext.js
@@ -9,7 +9,7 @@ export function injectRules(Component) {
 
     return (
       <RulesContext.Consumer>
-        {rules => <Component {...props} rules={rules} />}
+        {({ rules, loading } = {}) => <Component {...props} rules={rules} loadingRules={loading} />}
       </RulesContext.Consumer>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, we want to add UX possibilities.

#### What problem is this solving?

With that, the consumers can react to the loading rules state. In the Logistics case, disable the fields when loading rules since they might not apply to the new ones.

#### How should this be manually tested?

[Workspace](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/).

#### Screenshots or example usage


https://user-images.githubusercontent.com/15948386/129102311-789b796e-ac0f-4f7d-8dee-99c031e91623.mov


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
