### PR TITLE
CHK-853: Address fields with value `null` being marked as `geolocationAutoCompleted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adress fields with null value being marked with `geolocationAutoCompleted` flag
 
 ## [3.18.7] - 2021-07-29
 ### Fixed

--- a/react/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
+++ b/react/geolocation/__snapshots__/geolocationAutoCompleteAddress.test.js.snap
@@ -17,7 +17,7 @@ Object {
     "value": "Rio de Janeiro",
   },
   "complement": Object {
-    "geolocationAutoCompleted": true,
+    "geolocationAutoCompleted": false,
     "value": null,
   },
   "country": Object {
@@ -54,7 +54,7 @@ Object {
     "valueOptions": undefined,
   },
   "reference": Object {
-    "geolocationAutoCompleted": true,
+    "geolocationAutoCompleted": false,
     "value": null,
   },
   "state": Object {

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -1,7 +1,11 @@
 import flow from 'lodash/flow'
 
 import getCountryISO2 from '../countryISOMap'
-import { addNewField, addFocusToNextInvalidField, createNewAddress } from '../transforms/address'
+import {
+  addNewField,
+  addFocusToNextInvalidField,
+  createNewAddress,
+} from '../transforms/address'
 
 export default function geolocationAutoCompleteAddress(
   baseAddress,
@@ -18,7 +22,11 @@ export default function geolocationAutoCompleteAddress(
     setCountry,
     setAddressQuery,
     (updatedAddress) =>
-      addNewField(updatedAddress, 'geolocationAutoCompleted', (fieldValue) => { return (fieldValue?.value !== null) }),
+      addNewField(
+        updatedAddress,
+        'geolocationAutoCompleted',
+        (fieldValue) => fieldValue?.value !== null
+      ),
     (updatedAddress) => ({
       ...updatedAddress,
       addressId: baseAddress.addressId,

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -18,7 +18,7 @@ export default function geolocationAutoCompleteAddress(
     setCountry,
     setAddressQuery,
     (updatedAddress) =>
-      addNewField(updatedAddress, 'geolocationAutoCompleted', true),
+      addNewField(updatedAddress, 'geolocationAutoCompleted', (fieldValue) => { return (fieldValue?.value !== null) }),
     (updatedAddress) => ({
       ...updatedAddress,
       addressId: baseAddress.addressId,

--- a/react/transforms/address.ts
+++ b/react/transforms/address.ts
@@ -62,32 +62,15 @@ export function removeValidation(address) {
 export function addNewField<FieldName extends keyof ValidatedField>(
   address: AddressWithValidation,
   fieldName: FieldName,
-  value: ValidatedField[FieldName] |  ((fieldValue: ValidatedField) => boolean)
+  value: ValidatedField[FieldName] | ((fieldValue: ValidatedField) => boolean)
 ): AddressWithValidation {
-  
-  if(value instanceof Function){
-    const newAddressEntries = Object.entries(address).map(
-      ([field, fieldValue]) => {
-        return [
-          field,
-          {
-            ...fieldValue,
-            [fieldName]: value(fieldValue),
-          },
-        ]
-      }
-    )
-
-  return Object.fromEntries(newAddressEntries)
-  }
-
   const newAddressEntries = Object.entries(address).map(
     ([field, fieldValue]) => {
       return [
         field,
         {
           ...fieldValue,
-          [fieldName]: value,
+          [fieldName]: typeof value === 'function' ? value(fieldValue) : value,
         },
       ]
     }

--- a/react/transforms/address.ts
+++ b/react/transforms/address.ts
@@ -62,7 +62,9 @@ export function removeValidation(address) {
 export function addNewField<FieldName extends keyof ValidatedField>(
   address: AddressWithValidation,
   fieldName: FieldName,
-  value: ValidatedField[FieldName] | ((fieldValue: ValidatedField) => boolean)
+  value:
+    | ValidatedField[FieldName]
+    | ((fieldValue: ValidatedField) => ValidatedField[FieldName])
 ): AddressWithValidation {
   const newAddressEntries = Object.entries(address).map(
     ([field, fieldValue]) => {

--- a/react/transforms/address.ts
+++ b/react/transforms/address.ts
@@ -62,8 +62,25 @@ export function removeValidation(address) {
 export function addNewField<FieldName extends keyof ValidatedField>(
   address: AddressWithValidation,
   fieldName: FieldName,
-  value: ValidatedField[FieldName]
+  value: ValidatedField[FieldName] |  ((fieldValue: ValidatedField) => boolean)
 ): AddressWithValidation {
+  
+  if(value instanceof Function){
+    const newAddressEntries = Object.entries(address).map(
+      ([field, fieldValue]) => {
+        return [
+          field,
+          {
+            ...fieldValue,
+            [fieldName]: value(fieldValue),
+          },
+        ]
+      }
+    )
+
+  return Object.fromEntries(newAddressEntries)
+  }
+
   const newAddressEntries = Object.entries(address).map(
     ([field, fieldValue]) => {
       return [

--- a/react/types/address.ts
+++ b/react/types/address.ts
@@ -40,7 +40,7 @@ export type AddressValues = Address[Fields]
 
 export interface ValidatedField {
   value?: string
-  valueOptions?: unknown
+  valueOptions?: any
   valid?: boolean
   reason?: string
   visited?: boolean


### PR DESCRIPTION
#### What is the purpose of this pull request?
With [this](https://github.com/vtex/address-form/pull/386) previous pull request, address fields with value `null` were being marked with the flag `geolocationAutoCompleted`, which they shouldn't. This pull request guarantees that when a field has `null` as its value, it will not be marked as autocompleted.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Go here](https://autocompl--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2). Go to shipping and input the address 'Charles Hamilton Las Condes, Santiago, Chile' with no number. Then, make sure the field to input the address number appears and can be filled. 

#### Screenshots or example usage
Before
<img width="324" alt="Screen Shot 2021-08-12 at 3 34 55 PM" src="https://user-images.githubusercontent.com/49081447/129250409-00786078-8e39-442c-911f-a3b074c92b8e.png">

After
<img width="321" alt="Screen Shot 2021-08-12 at 3 35 31 PM" src="https://user-images.githubusercontent.com/49081447/129250449-f42d7464-91e0-4f78-8622-a90ecdeef152.png">


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
