### PR TITLE
[LOGB2C-828] Add rules error handling to AddressRules and optional prop to always use the default rules as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `GeolocationInput` optional `autocompleteOptions` prop.
-- `loadingRules` to `AddressRulesContext` to enhance UX possibilities.
+- `loadingRules`, `rulesError` and `fetchRules` to `AddressRulesContext` to enhance UX possibilities.
+- `AddressRules` optional `useDefaultRulesAsFallback` prop.
 
 ## [4.8.0] - 2021-08-03
 

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -44,13 +44,12 @@ class AddressRules extends Component {
         return ruleData.default || ruleData
       })
       .catch((error) => {
-        this.setState({ error })
-        const errorType = this.parseError(error)
+        const notFoundErrorType = this.parseError(error)
 
-        if (errorType || this.props.useDefaultRulesAsFallback) {
+        if (notFoundErrorType) {
           if (process.env.NODE_ENV !== 'production') {
             console.warn(
-              `Couldn't load rules for country ${errorType}, using default rules instead.`,
+              `Couldn't load rules for country ${notFoundErrorType}, using default rules instead.`,
             )
           }
           return defaultRules
@@ -58,6 +57,14 @@ class AddressRules extends Component {
 
         if (process.env.NODE_ENV !== 'production') {
           console.error('An unknown error occurred.', error)
+        }
+
+        if (this.props.useDefaultRulesAsFallback) {
+          // Since not found rules can happen quite frequently,
+          // only unexpected errors should notify the consumers.
+          this.setState({ error })
+
+          return defaultRules
         }
       })
       .finally(() => {

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -13,6 +13,7 @@ class AddressRules extends Component {
       country: null,
       rules: null,
       loadingRules: false,
+      error: null,
     }
   }
 
@@ -38,10 +39,15 @@ class AddressRules extends Component {
   fetchRules(rulePromise) {
     this.setState({ loadingRules: true })
     return rulePromise
-      .then(ruleData => ruleData.default || ruleData)
-      .catch(error => {
+      .then((ruleData) => {
+        this.setState({ error: null })
+        return ruleData.default || ruleData
+      })
+      .catch((error) => {
+        this.setState({ error })
         const errorType = this.parseError(error)
-        if (errorType) {
+
+        if (errorType || this.props.useDefaultRulesAsFallback) {
           if (process.env.NODE_ENV !== 'production') {
             console.warn(
               `Couldn't load rules for country ${errorType}, using default rules instead.`,
@@ -53,7 +59,8 @@ class AddressRules extends Component {
         if (process.env.NODE_ENV !== 'production') {
           console.error('An unknown error occurred.', error)
         }
-      }).finally(() => {
+      })
+      .finally(() => {
         this.setState({ loadingRules: false })
       })
   }
@@ -73,7 +80,7 @@ class AddressRules extends Component {
         // set a hidden flag for internal usage
         _usingGeolocationRules: true,
         // overwrite field with configs defined on `rules.geolocation`
-        fields: rules.fields.map(field => {
+        fields: rules.fields.map((field) => {
           if (rules.geolocation[field.name]) {
             // ignore unrelated props for the field
             // eslint-disable-next-line no-unused-vars
@@ -93,12 +100,21 @@ class AddressRules extends Component {
 
   render() {
     const { children } = this.props
-    const { rules, loadingRules } = this.state
+    const { rules, loadingRules, error } = this.state
 
     if (!rules) return null
 
     return (
-      <RulesContext.Provider value={{ rules, loadingRules }}>{children}</RulesContext.Provider>
+      <RulesContext.Provider
+        value={{
+          rules,
+          loadingRules,
+          fetchRules: this.updateRules.bind(this),
+          rulesError: error,
+        }}
+      >
+        {children}
+      </RulesContext.Provider>
     )
   }
 }
@@ -111,6 +127,8 @@ AddressRules.propTypes = {
   shouldUseIOFetching: PropTypes.bool,
   /** Whether the rules should contemplate the geolocation field rules */
   useGeolocation: PropTypes.bool,
+  /** Whether to always use the default rules as fallback or not */
+  useDefaultRulesAsFallback: PropTypes.bool,
 }
 
 export default AddressRules

--- a/react/addressRulesContext.js
+++ b/react/addressRulesContext.js
@@ -9,7 +9,15 @@ export function injectRules(Component) {
 
     return (
       <RulesContext.Consumer>
-        {({ rules, loadingRules } = {}) => <Component {...props} rules={rules} loadingRules={loadingRules} />}
+        {({ rules, loadingRules, rulesError, fetchRules } = {}) => (
+          <Component
+            {...props}
+            rules={rules}
+            loadingRules={loadingRules}
+            rulesError={rulesError}
+            fetchRules={fetchRules}
+          />
+        )}
       </RulesContext.Consumer>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, adding the error handling would enhance the possible UX implementations.

#### What problem is this solving?

- No error handling, so if the rules don't load, the `AddressRules`'s children won't load;
- No way of trying to load the rules if an error occurs;
- There was no way of telling the app to load the default rules if an error occurs to load the current rules (a scenario that could happen if the network connection is flaky).

#### How should this be manually tested?

[Workspace](https://geolocation--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/). If you set the browser to offline, the default rules will be applied but the fields are disabled.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/129608666-569f3a77-c83f-4b9d-b1f9-82aed974db29.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
