### PR TITLE
[LOGB2C-894] Add `field.placeholder` and `field.fixedLabel` usage in all StyleguideInput cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `field.placeholder` and `field.fixedLabel` usage in all `StyleguideInput` field cases.
+
 ## [4.9.0] - 2021-08-23
 
 ### Added

--- a/react/geolocation/GeolocationInput.js
+++ b/react/geolocation/GeolocationInput.js
@@ -26,7 +26,7 @@ class GeolocationInput extends Component {
     })
   }
 
-  handleMountInput = input => {
+  handleMountInput = (input) => {
     const { useSearchBox, rules, googleMaps, autocompleteOptions } = this.props
 
     if (!input) {
@@ -98,7 +98,7 @@ class GeolocationInput extends Component {
         if (!firstPlaceFound.address_components) {
           this.geocoder.geocode(
             { address: firstPlaceFound.formatted_address },
-            address => (firstPlaceFound = address),
+            (address) => (firstPlaceFound = address),
           )
         }
 
@@ -110,12 +110,12 @@ class GeolocationInput extends Component {
     )
   }
 
-  handleAddress = googleAddress => {
+  handleAddress = (googleAddress) => {
     this.handleChangeInput(googleAddress.formatted_address)
     this.handlePlaceChanged(googleAddress)
   }
 
-  handlePlaceChanged = googleAddress => {
+  handlePlaceChanged = (googleAddress) => {
     const address = geolocationAutoCompleteAddress(
       this.state.address,
       googleAddress,
@@ -125,8 +125,8 @@ class GeolocationInput extends Component {
     this.props.onChangeAddress(address)
   }
 
-  handleChangeInput = value => {
-    this.setState(prevState => ({
+  handleChangeInput = (value) => {
+    this.setState((prevState) => ({
       address: {
         ...prevState.address,
         addressQuery: {
@@ -159,17 +159,21 @@ class GeolocationInput extends Component {
       },
     }
 
+    const field = (rules.fields &&
+      rules.fields.length > 0 &&
+      rules.fields.find((field) => field.name === 'addressQuery')) || {
+      label: 'addressQuery',
+      name: 'addressQuery',
+    }
+
     return (
       <Input
         {...inputProps}
         key={rules.country}
-        field={{
-          label: 'addressQuery',
-          name: 'addressQuery',
-        }}
+        field={field}
         options={null}
         address={newAddress}
-        placeholder={placeholder}
+        placeholder={field.placeholder || placeholder}
         autoFocus={autoFocus}
         onChange={!loadingGoogle ? this.handleChangeInput : () => {}}
         inputRef={!loadingGoogle ? this.handleMountInput : undefined}
@@ -200,9 +204,5 @@ GeolocationInput.propTypes = {
   autocompleteOptions: PropTypes.object,
 }
 
-const enhance = compose(
-  injectAddressContext,
-  injectRules,
-  injectIntl,
-)
+const enhance = compose(injectAddressContext, injectRules, injectIntl)
 export default enhance(GeolocationInput)

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -73,9 +73,16 @@ class StyleguideInput extends Component {
     const type = shouldShowNumberKeyboard ? 'tel' : 'text'
 
     const inputCommonProps = {
-      label: this.props.intl.formatMessage({
-        id: `address-form.field.${field.name}`,
-      }),
+      label:
+        field.fixedLabel ||
+        this.props.intl.formatMessage({
+          id: `address-form.field.${field.label}`,
+          defaultMessage: this.props.intl.formatMessage({
+            id: `address-form.field.${field.name}`,
+            defaultMessage: '',
+          }),
+        }),
+      placeholder: field.placeholder,
       autoFocus,
       value: address[field.name].value || '',
       disabled,
@@ -96,7 +103,9 @@ class StyleguideInput extends Component {
 
     const commonClassNames = `vtex-address-form__${
       field.name
-    } vtex-address-form__field--${field.size || 'xlarge'} ${field.hidden ? 'dn' : ''}`
+    } vtex-address-form__field--${field.size || 'xlarge'} ${
+      field.hidden ? 'dn' : ''
+    }`
 
     if (field.name === 'postalCode') {
       return (
@@ -135,32 +144,21 @@ class StyleguideInput extends Component {
       return (
         <div className={`${commonClassNames} flex flex-row pb7`}>
           <Input
-            label={
-              field.fixedLabel ||
-              intl.formatMessage({ id: `address-form.field.${field.label}` })
-            }
-            errorMessage={
-              address[field.name].reason && this.state.showErrorMessage
-                ? this.props.intl.formatMessage({
-                    id: `address-form.error.${address[field.name].reason}`,
+            {...inputCommonProps}
+            placeholder={
+              inputCommonProps.placeholder != null
+                ? inputCommonProps.placeholder
+                : intl.formatMessage({
+                    id: `address-form.geolocation.example.${
+                      address.country.value || 'UNI'
+                    }`,
+                    defaultMessage: intl.formatMessage({
+                      id: 'address-form.geolocation.example.UNI',
+                    }),
                   })
-                : undefined
             }
-            placeholder={intl.formatMessage({
-              id: `address-form.geolocation.example.${address.country.value}`,
-              defaultMessage: intl.formatMessage({
-                id: 'address-form.geolocation.example.UNI',
-              }),
-            })}
-            onChange={this.handleChange}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-            autoFocus={autoFocus}
             disabled={loading || disabled}
-            error={!this.state.isInputValid}
-            ref={inputRef}
             suffix={<SpinnerLoading isLoading={loading} />}
-            value={address[field.name].value || ''}
           />
         </div>
       )
@@ -175,32 +173,17 @@ class StyleguideInput extends Component {
           className={`vtex-address-form__number-div ${commonClassNames} flex flex-row pb7`}
         >
           <div className="vtex-address-form__number-input flex w-50">
-            <Input
-              label={
-                field.fixedLabel ||
-                intl.formatMessage({ id: `address-form.field.${field.label}` })
-              }
-              errorMessage={
-                address[field.name].reason && this.showErrorMessage
-                  ? this.props.intl.formatMessage({
-                      id: `address-form.error.${address[field.name].reason}`,
-                    })
-                  : undefined
-              }
-              autoFocus={autoFocus}
-              onChange={this.handleChange}
-              onBlur={this.handleBlur}
-              onFocus={this.handleFocus}
-              disabled={loading || disabled}
-              error={!this.state.isInputValid}
-              ref={inputRef}
-              value={address[field.name].value || ''}
-            />
+            <Input {...inputCommonProps} disabled={loading || disabled} />
           </div>
           <div className="vtex-address-form__number-checkbox flex flex-row ml7 mt6 w-50">
             <Checkbox
               id="option-0"
-              label={this.props.notApplicableLabel || 'N/A'}
+              label={
+                this.props.notApplicableLabel ||
+                intl.formatMessage({
+                  id: `address-form.field.notApplicable`,
+                })
+              }
               name="default-checkbox-group"
               onChange={toggleNotApplicable}
               value="op"
@@ -214,17 +197,7 @@ class StyleguideInput extends Component {
     if (options) {
       return (
         <div className={`${commonClassNames} pb6`}>
-          <Dropdown
-            options={options}
-            value={address[field.name].value || ''}
-            disabled={disabled}
-            ref={inputRef}
-            label={intl.formatMessage({
-              id: `address-form.field.${field.label}`,
-            })}
-            onChange={this.handleChange}
-            onBlur={this.handleBlur}
-          />
+          <Dropdown {...inputCommonProps} options={options} />
         </div>
       )
     }
@@ -232,30 +205,16 @@ class StyleguideInput extends Component {
     return (
       <div className={`${commonClassNames} pb7`}>
         <Input
-          label={this.props.intl.formatMessage({
-            id: `address-form.field.${field.label}`,
-          })}
-          errorMessage={
-            address[field.name].reason
-              ? intl.formatMessage({
-                  id: `address-form.error.${address[field.name].reason}`,
-                })
-              : undefined
-          }
-          value={address[field.name].value || ''}
-          disabled={disabled}
-          error={!this.state.isInputValid}
+          {...inputCommonProps}
           maxLength={`${field.maxLength}`}
-          ref={inputRef}
           placeholder={
-            !field.hidden && !field.required
+            // Avoid empty string replacement
+            inputCommonProps.placeholder != null
+              ? inputCommonProps.placeholder
+              : !field.hidden && !field.required
               ? this.props.intl.formatMessage({ id: 'address-form.optional' })
               : null
           }
-          onBlur={this.handleBlur}
-          autoFocus={autoFocus}
-          onChange={this.handleChange}
-          onFocus={this.handleFocus}
         />
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

We want to enhance the UX possibilities when using the `vtex.address-form` app.

#### What problem is this solving?

As the title says, we want to be able to use custom labels and placeholders in fields.

#### How should this be manually tested?

[Workspace](https://newdockaddress--logisticsqa.myvtex.com/admin/app/shipping-strategy/loading-dock/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/130820667-337746ed-061d-4662-a767-047e7f876879.png)

![image](https://user-images.githubusercontent.com/15948386/130820698-22388dd0-581f-444b-9443-ed4c9291eea2.png)

The ZIP label:

![image](https://user-images.githubusercontent.com/15948386/130820767-d182012d-8357-48ce-bf35-4841813ef327.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
