### PR TITLE
CHK-981: Activate postal code API for Portugal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Activate postal code API for Portugal
 
 ## [3.20.2] - 2021-10-21
 ### Added

--- a/react/country/PRT.js
+++ b/react/country/PRT.js
@@ -19,7 +19,7 @@ export default {
       required: true,
       mask: '9999-999',
       regex: '^(?:[\\d]{4})(?:\\-|)(?:[\\d]{3})$',
-      postalCodeAPI: false,
+      postalCodeAPI: true,
       forgottenURL:
         'https://www.ctt.pt/feapl_2/app/open/objectSearch/objectSearch.jspx',
       size: 'small',


### PR DESCRIPTION
#### What is the purpose of this pull request?

As title says. Fixes [this escalation](https://vtex.slack.com/archives/C017NPK8U86/p1634932005100600).

#### What problem is this solving?

Postal codes were added to Portugal API, so this configuration should change. @garrucho explained it:

> the configuration for PRT isn't using the postalCode API to autocomplete the address. this is happening only on the API layer, which doesn't update the information.
as an example, in Brazil this is made since the UI. so we just need to enable the same behavior for PRT.

#### How should this be manually tested?

1. [Cartlink](https://prt--quebramar.myvtex.com/checkout/cart/add/?sku=5062&qty=1&seller=1&sc=1)
2. Go to shipping step on checkout
3. Use postal code `4445-172`. It should show "Alfena VLG"
4. Change the postal code to `1000-004`. It should show "Lisboa LSB"

Before the fix, only the first postal code would return an address and wouldn't change later on. So "Alfena VLG" would stay for `1000-004` for this.