### PR TITLE
L18n 3 europe

### DIFF
--- a/react/country/AUT.js
+++ b/react/country/AUT.js
@@ -1,0 +1,142 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'AUT',
+  abbr: 'AT',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 4,
+      label: 'postalCode',
+      required: true,
+      mask: '9999',
+      regex: /^[1-9]\d{3}$/,  //4 digits, cannot start with leading zero
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Burgenland', 
+        'Kärnten', 
+        'Niederösterreich', 
+        'Oberösterreich', 
+        'Salzburg', 
+        'Steiermark', 
+        'Tirol', 
+        'Vorarlberg', 
+        'Wien'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/BEL.js
+++ b/react/country/BEL.js
@@ -1,0 +1,104 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'BEL',
+  abbr: 'BE',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      label: 'postalCode',
+      maxLength: 4,
+      required: true,
+      mask: '9999',
+      regex: /^\d{4}$/,
+      postalCodeAPI: false,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'department',
+      required: true,
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+      handler: (address, googleAddress) => {
+        address.street = { value: googleAddress.name }
+
+        return address
+      },
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['locality'],
+    },
+
+    state: {
+      valueIn: 'short_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [{ name: 'complement' }],
+    [{ name: 'street' }],
+    [{ name: 'postalCode' }, { delimiter: ' ', name: 'city' }],
+  ],
+}

--- a/react/country/BGR.js
+++ b/react/country/BGR.js
@@ -1,0 +1,161 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'BGR',
+  abbr: 'BG',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 4,
+      label: 'postalCode',
+      required: true,
+      mask: '9999',
+      regex: /^[1-9]\d{3}$/,   // 4 digits, no leading zero.
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Област Благоевград', 
+        'Област Бургас', 
+        'Област Варна', 
+        'Област Велико Търново', 
+        'Област Видин', 
+        'Област Враца', 
+        'Област Габрово', 
+        'Област Добрич', 
+        'Област Кърджали', 
+        'Област Кюстендил', 
+        'Област Ловеч', 
+        'Област Монтана', 
+        'Област Пазарджик', 
+        'Област Перник', 
+        'Област Плевен', 
+        'Област Пловдив', 
+        'Област Разград', 
+        'Област Русе', 
+        'Област Силистра', 
+        'Област Сливен', 
+        'Област Смолян', 
+        'Софийска област', 
+        'Област София', 
+        'Област Стара Загора', 
+        'Област Търговище', 
+        'Област Хасково', 
+        'Област Шумен', 
+        'Област Ямбол'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/CZE.js
+++ b/react/country/CZE.js
@@ -1,0 +1,147 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'CZE',
+  abbr: 'CZ',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 6,
+      label: 'postalCode',
+      required: true,
+      mask: '999 99',
+      regex: /^[1-7]\d{2}\ \d{2}$/,  //shares zipcodes with slovakia. Numbers 8,9,0 are reserved there. 
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Hlavní město Praha', 
+        'Středočeský kraj', 
+        'Jihočeský kraj', 
+        'Plzeňský kraj', 
+        'Karlovarský kraj', 
+        'Ústecký kraj', 
+        'Liberecký kraj', 
+        'Královéhradecký kraj', 
+        'Pardubický kraj', 
+        'Kraj Vysočina', 
+        'Jihomoravský kraj', 
+        'Olomoucký kraj', 
+        'Moravskoslezský kraj', 
+        'Zlínský kraj'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/DEU.js
+++ b/react/country/DEU.js
@@ -1,0 +1,149 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'DEU',
+  abbr: 'DE',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 5,
+      label: 'postalCode',
+      required: true,
+      mask: '99999',
+      regex: /^\d{5}$/,
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Baden-Württemberg',
+        'Bayern',
+        'Berlin', 
+        'Brandenburg', 
+        'Bremen', 
+        'Hamburg', 
+        'Hessen', 
+        'Mecklenburg-Vorpommern', 
+        'Niedersachsen', 
+        'Nordrhein-Westfalen', 
+        'Rheinland-Pfalz', 
+        'Saarland', 
+        'Sachsen', 
+        'Sachsen-Anhalt', 
+        'Schleswig-Holstein',
+        'Thüringen'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/HRV.js
+++ b/react/country/HRV.js
@@ -1,0 +1,154 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'HRV',
+  abbr: 'HR',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 5,
+      label: 'postalCode',
+      required: true,
+      mask: '99999',
+      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}/$ //starting codes are limited to that list.
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Zagrebačka županija',
+        'Krapinsko-zagorska županija',
+        'Sisačko-moslavačka županija',
+        'Karlovačka županija',
+        'Varaždinska županija',
+        'Koprivničko-križevačka županija',
+        'Bjelovarsko-bilogorska županija',
+        'Primorsko-goranska županija',
+        'Ličko-senjska županija',
+        'Virovitičko-podravska županija',
+        'Požeško-slavonska županija',
+        'Brodsko-posavska županija',
+        'Zadarska županija',
+        'Osječko-baranjska županija',
+        'Šibensko-kninska županija',
+        'Vukovarsko-srijemska županija',
+        'Splitsko-dalmatinska županija',
+        'Istarska županija',
+        'Dubrovačko-neretvanska županija',
+        'Međimurska županija',
+        'Grad Zagreb'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/HRV.js
+++ b/react/country/HRV.js
@@ -19,7 +19,7 @@ export default {
       label: 'postalCode',
       required: true,
       mask: '99999',
-      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}$/
+      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}$/,
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/HRV.js
+++ b/react/country/HRV.js
@@ -19,7 +19,7 @@ export default {
       label: 'postalCode',
       required: true,
       mask: '99999',
-      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}/$ //starting codes are limited to that list.
+      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}/$, //starting codes are limited to that list.
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/HRV.js
+++ b/react/country/HRV.js
@@ -19,7 +19,7 @@ export default {
       label: 'postalCode',
       required: true,
       mask: '99999',
-      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}/$, //starting codes are limited to that list.
+      regex: /^(10|20|21|22|23|31|32|33|34|35|40|42|43|44|47|48|49|51|52|53)\d{3}$/
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/IRL.js
+++ b/react/country/IRL.js
@@ -1,0 +1,141 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'IRL',
+  abbr: 'IE',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 8,
+      label: 'postalCode',
+      required: true,
+      mask: '999 9999',
+      regex: /(?:^[AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?[0-9AC-FHKNPRTV-Y]{4}$/,
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Border', 
+        'West', 
+        'Mid-West', 
+        'South-East', 
+        'South-West', 
+        'Dublin', 
+        'Mid-East', 
+        'Midlands'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/NLD.js
+++ b/react/country/NLD.js
@@ -1,0 +1,104 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'NLD',
+  abbr: 'NL',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      label: 'postalCode',
+      maxLength: 7,
+      required: true,
+      mask: '9999 AA',
+      regex: /^[1-9][0-9]{3} ?(?!sa|sd|ss)[a-zA-Z]{2}$/,
+      postalCodeAPI: false,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'department',
+      required: true,
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+      handler: (address, googleAddress) => {
+        address.street = { value: googleAddress.name }
+
+        return address
+      },
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['locality'],
+    },
+
+    state: {
+      valueIn: 'short_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [{ name: 'complement' }],
+    [{ name: 'street' }],
+    [{ name: 'postalCode' }, { delimiter: ' ', name: 'city' }],
+  ],
+}

--- a/react/country/POL.js
+++ b/react/country/POL.js
@@ -19,7 +19,7 @@ export default {
       label: 'postalCode',
       required: true,
       mask: '99-999',
-      regex: /^\d{2}\-\d{3}$/
+      regex: /^\d{2}\-\d{3}$/,
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/POL.js
+++ b/react/country/POL.js
@@ -1,0 +1,149 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'POL',
+  abbr: 'PL',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 6,
+      label: 'postalCode',
+      required: true,
+      mask: '99-999',
+      regex: /^\d{2}\-\d{3}$/
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'wielkopolskie', 
+        'kujawsko-pomorskie', 
+        'małopolskie', 
+        'łódzkie', 
+        'dolnośląskie', 
+        'lubelskie', 
+        'lubuskie', 
+        'mazowieckie', 
+        'opolskie', 
+        'podlaskie', 
+        'pomorskie', 
+        'śląskie', 
+        'podkarpackie', 
+        'świętokrzyskie', 
+        'warmińsko-mazurskie', 
+        'zachodniopomorskie'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/SRB.js
+++ b/react/country/SRB.js
@@ -19,7 +19,7 @@ export default {
       label: 'postalCode',
       required: true,
       mask: '99999',
-      regex: /^[1,2,3]\d{4}/, //has to start on 1, 2 or 3.
+      regex: /^[123]\d{4}/, //has to start on 1, 2 or 3.
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/SRB.js
+++ b/react/country/SRB.js
@@ -1,0 +1,123 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'SRB',
+  abbr: 'RS',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 5,
+      label: 'postalCode',
+      required: true,
+      mask: '99999',
+      regex: /^[1,2,3]\d{4}/, //has to start on 1, 2 or 3.
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/SVK.js
+++ b/react/country/SVK.js
@@ -19,7 +19,7 @@ export default {
       label: 'postalCode',
       required: true,
       mask: '999 99',
-      regex: /^[0,8,9]\d{2}\ \d{2}$/, //shares zipcode range with Czech republic, 1-7 are reserved there.
+      regex: /^[089]\d{2}\ \d{2}$/, //shares zipcode range with Czech republic, 1-7 are reserved there.
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/SVK.js
+++ b/react/country/SVK.js
@@ -1,0 +1,141 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'SVK',
+  abbr: 'SK',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 6,
+      label: 'postalCode',
+      required: true,
+      mask: '999 99',
+      regex: /^[0,8,9]\d{2}\ \d{2}$/, //shares zipcode range with Czech republic, 1-7 are reserved there.
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'Bratislava', 
+        'Trnava', 
+        'Trenčín', 
+        'Nitra', 
+        'Žilina', 
+        'Banská Bystrica', 
+        'Prešov', 
+        'Košice'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}

--- a/react/country/UKR.js
+++ b/react/country/UKR.js
@@ -1,0 +1,158 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'UKR',
+  abbr: 'UA',
+  postalCodeFrom: POSTAL_CODE,
+  postalCodeProtectedFields: ['state'],
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 5,
+      label: 'postalCode',
+      required: true,
+      mask: '99999',
+      regex: /^\d{5}$/,
+      postalCodeAPI: true,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'street',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'floorAndLetter',
+      size: 'large',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'province',
+      required: true,
+      optionsCaption: '',
+      options: [
+        'АР Крим', 
+        'Вінницька', 
+        'Волинська', 
+        'Дніпропетровська', 
+        'Донецька', 
+        'Житомирська', 
+        'Закарпатська', 
+        'Запорізька', 
+        'Івано-Франківська', 
+        'Київська', 
+        'Кіровоградська', 
+        'Луганська', 
+        'Львівська', 
+        'МиколаївськаМиколаїв', 
+        'Одеська', 
+        'Полтавська', 
+        'Рівненська', 
+        'Сумська', 
+        'Тернопільська', 
+        'Харківська', 
+        'Херсонська', 
+        'Хмельницька', 
+        'Черкаська', 
+        'Чернівецька', 
+        'Чернігівська'
+      ],
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: ['neighborhood'],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      { name: 'street' },
+      { delimiter: ' ', name: 'number' },
+      { delimiter: ' ', name: 'complement' },
+    ],
+    [
+      { name: 'postalCode' },
+      { delimiter: ' ', name: 'city' },
+      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+    ],
+  ],
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

adding 12 more european countries for the address form validation

#### What problem is this solving?

Motorola is active in these countries already, we had an issue where a Dutch zip code was used to order on the belgian site. 

#### How should this be manually tested?
throw zip codes towards the UI, compare the list of regions.
#### Screenshots or example usage
--
#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
