### PR TITLE
[LOGB2C-916] Fix address validation when there are null values for optional fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Address validation when there are null values.
+
 ## [4.12.0] - 2021-11-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Address validation when there are null values.
+- Address validation when there are null values for optional fields.
 
 ## [4.12.0] - 2021-11-04
 

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -146,10 +146,6 @@ const invalidGeoCoords = { valid: false, reason: EGEOCOORDS }
 const invalidPostalCode = { valid: false, reason: EPOSTALCODE }
 
 function valueInOptions(value, options) {
-  if (value == null) {
-    return false
-  }
-
   const normalizedValue = value.toLowerCase()
   const normalizedOptions = options.map((option) => option.toLowerCase())
 
@@ -158,12 +154,10 @@ function valueInOptions(value, options) {
 
 function valueInOptionsPairs(value, optionsPairs) {
   return (
-    (value != null &&
-      find(
-        optionsPairs,
-        (optionPair) => optionPair.value.toLowerCase() === value.toLowerCase()
-      )) ||
-    false
+    find(
+      optionsPairs,
+      (optionPair) => optionPair.value.toLowerCase() === value.toLowerCase()
+    ) || false
   )
 }
 
@@ -202,7 +196,7 @@ function defaultValidation(value, name, address, rules) {
     return emptyField
   }
 
-  if (field && hasOptions(field)) {
+  if (field && value && hasOptions(field)) {
     return validateOptions(value, field, address, rules)
   }
 

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -1,5 +1,6 @@
 import reduce from 'lodash/reduce'
 import find from 'lodash/find'
+
 import { hasOptions, getField, getListOfOptions } from './selectors/fields'
 import { addFocusToNextInvalidField } from './transforms/address'
 import {
@@ -13,7 +14,10 @@ import {
 
 export function isValidAddress(address, rules) {
   const validatedAddress = addFocusToNextInvalidField(address, rules)
-  const hasInvalidField = find(validatedAddress, field => field.valid === false)
+  const hasInvalidField = find(
+    validatedAddress,
+    (field) => field.valid === false
+  )
 
   return {
     valid: !hasInvalidField,
@@ -30,9 +34,10 @@ export function validateAddress(address, rules) {
         valueOptions,
         ...validateField(value, name, address, rules),
       }
+
       return memo
     },
-    {},
+    {}
   )
 }
 
@@ -41,7 +46,7 @@ export function validateChangedFields(changedFields, address, rules) {
   const visitedFields = reduce(
     changedFields,
     (acc, field, name) => (field.visited ? acc.concat([name]) : acc),
-    [],
+    []
   )
 
   const newAddress = {
@@ -56,7 +61,7 @@ export function validateChangedFields(changedFields, address, rules) {
         resultAddress[fieldName].value,
         fieldName,
         resultAddress,
-        rules,
+        rules
       )
 
       const isVisited = visitedFields.indexOf(fieldName) !== -1
@@ -82,9 +87,10 @@ export function validateChangedFields(changedFields, address, rules) {
         ...resultAddress[fieldName],
         ...(showValidationResult ? validationResult : {}),
       }
+
       return resultAddress
     },
-    newAddress,
+    newAddress
   )
 }
 
@@ -92,25 +98,40 @@ export function validateField(value, name, address, rules) {
   switch (name) {
     case 'addressId':
       return validateAddressId(value, name, address, rules)
+
     case 'addressType':
       return validateAddressType(value, name, address, rules)
+
     case 'country':
       return validateCountry(value, name, address, rules)
+
     case 'geoCoordinates':
       return validateGeoCoordinates(value, name, address, rules)
+
     case 'postalCode':
       return validatePostalCode(value, name, address, rules)
+
     case 'city':
+
     case 'complement':
+
     case 'neighborhood':
+
     case 'number':
+
     case 'receiverName':
+
     case 'reference':
+
     case 'state':
+
     case 'street':
+
     case 'addressQuery':
+
     case 'isDisposable':
       return defaultValidation(value, name, address, rules)
+
     default:
       console.warn(`Unexpected field ${name}`)
   }
@@ -125,17 +146,24 @@ const invalidGeoCoords = { valid: false, reason: EGEOCOORDS }
 const invalidPostalCode = { valid: false, reason: EPOSTALCODE }
 
 function valueInOptions(value, options) {
+  if (value == null) {
+    return false
+  }
+
   const normalizedValue = value.toLowerCase()
-  const normalizedOptions = options.map(option => option.toLowerCase())
+  const normalizedOptions = options.map((option) => option.toLowerCase())
+
   return normalizedOptions.indexOf(normalizedValue) !== -1
 }
 
 function valueInOptionsPairs(value, optionsPairs) {
   return (
-    find(
-      optionsPairs,
-      optionPair => optionPair.value.toLowerCase() === value.toLowerCase(),
-    ) || false
+    (value != null &&
+      find(
+        optionsPairs,
+        (optionPair) => optionPair.value.toLowerCase() === value.toLowerCase()
+      )) ||
+    false
   )
 }
 
@@ -227,6 +255,7 @@ function validatePostalCode(value, name, address, rules) {
   // a not-required empty postal code should be valid
   if (field.regex && value) {
     const regExp = new RegExp(field.regex)
+
     if (regExp.test(value) === false) {
       return invalidPostalCode
     }

--- a/react/validateAddress.test.js
+++ b/react/validateAddress.test.js
@@ -49,23 +49,30 @@ describe('Address Validation:', () => {
       expect(result.valid).toBe(false)
     })
 
-    it('should return false if a field with option pairs is null and not required', () => {
-      const invalidAddress = {
+    it('should not throw and return true if a field with option pairs is null and not required', () => {
+      const validAddress = {
         ...address,
         postalCode: { value: '22231000' },
         city: { value: 'Rio de Janeiro' },
+        street: { value: 'Praia de Botafogo' },
+        number: { value: '300' },
+        neighborhood: { value: 'Botafogo' },
+        receiverName: { value: 'Linus' },
+        // Field with optionsPairs in rules
         state: { value: null },
       }
 
-      const result = isValidAddress(invalidAddress, {
-        ...usePostalCode,
-        fields: usePostalCode.fields.map((field) => ({
-          ...field,
-          required: field.name !== 'state' && field.required,
-        })),
-      })
+      const validate = () =>
+        isValidAddress(validAddress, {
+          ...usePostalCode,
+          fields: usePostalCode.fields.map((field) => ({
+            ...field,
+            required: field.name !== 'state' && field.required,
+          })),
+        })
 
-      expect(result.valid).toBe(false)
+      expect(validate).not.toThrow()
+      expect(validate().valid).toBe(true)
     })
 
     it('should focus on the next invalid field', () => {

--- a/react/validateAddress.test.js
+++ b/react/validateAddress.test.js
@@ -1,3 +1,5 @@
+import reduce from 'lodash/reduce'
+
 import {
   isValidAddress,
   validateAddress,
@@ -5,7 +7,6 @@ import {
   validateField,
 } from './validateAddress'
 import address from './__mocks__/newAddress'
-import reduce from 'lodash/reduce'
 import usePostalCode from './country/__mocks__/usePostalCode'
 import {
   EEMPTY,
@@ -22,7 +23,7 @@ describe('Address Validation:', () => {
   function getRulesRequiredFields(rules, withBaseRequiredFields = true) {
     return rules.fields.reduce(
       (acc, field) => (field.required ? acc.concat([field.name]) : acc),
-      withBaseRequiredFields ? [...baseRequiredFields] : [],
+      withBaseRequiredFields ? [...baseRequiredFields] : []
     )
   }
 
@@ -30,7 +31,7 @@ describe('Address Validation:', () => {
     return reduce(
       validationResult,
       (acc, value, field) => (value.valid ? acc : acc.concat([field])),
-      [],
+      []
     )
   }
 
@@ -44,6 +45,25 @@ describe('Address Validation:', () => {
       }
 
       const result = isValidAddress(invalidAddress, usePostalCode)
+
+      expect(result.valid).toBe(false)
+    })
+
+    it('should return false if a field with option pairs is null and not required', () => {
+      const invalidAddress = {
+        ...address,
+        postalCode: { value: '22231000' },
+        city: { value: 'Rio de Janeiro' },
+        state: { value: null },
+      }
+
+      const result = isValidAddress(invalidAddress, {
+        ...usePostalCode,
+        fields: usePostalCode.fields.map((field) => ({
+          ...field,
+          required: field.name !== 'state' && field.required,
+        })),
+      })
 
       expect(result.valid).toBe(false)
     })
@@ -88,7 +108,7 @@ describe('Address Validation:', () => {
         addressId: { value: null },
         addressType: { value: null },
       },
-      usePostalCode,
+      usePostalCode
     )
 
     const invalidFields = getAllInvalidFieldsNames(result)
@@ -242,7 +262,7 @@ describe('Address Validation:', () => {
       'AMAZON',
       'state',
       validAddress,
-      rules,
+      rules
     )
 
     expect(validcityOption.valid).toBe(true)
@@ -289,7 +309,7 @@ describe('Address Validation:', () => {
       validGeoCoords,
       'geoCoordinates',
       address,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(validResult.valid).toBe(true)
@@ -302,7 +322,7 @@ describe('Address Validation:', () => {
       invalidGeoCoords,
       'geoCoordinates',
       address,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(invalidResult.valid).toBe(false)
@@ -316,7 +336,7 @@ describe('Address Validation:', () => {
       invalidPostalCode,
       'postalCode',
       address,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(result.valid).toBe(false)
@@ -330,7 +350,7 @@ describe('Address Validation:', () => {
       validPostalCode,
       'postalCode',
       address,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(result.valid).toBe(true)
@@ -397,13 +417,21 @@ describe('Address Validation:', () => {
       postalCode: { value: '22231000' },
     }
 
-    const validatedAddress = validateChangedFields(changedFieldsValid, address, usePostalCode)
+    const validatedAddress = validateChangedFields(
+      changedFieldsValid,
+      address,
+      usePostalCode
+    )
 
     const changedFieldsValid2 = {
       postalCode: { value: '22231001' },
     }
 
-    const result = validateChangedFields(changedFieldsValid2, validatedAddress, usePostalCode)
+    const result = validateChangedFields(
+      changedFieldsValid2,
+      validatedAddress,
+      usePostalCode
+    )
 
     expect(result.postalCode.valid).toBe(true)
   })
@@ -412,10 +440,11 @@ describe('Address Validation:', () => {
     const changedFieldsValid = {
       postalCode: { value: '22231000' },
     }
+
     const validatedAddress = validateChangedFields(
       changedFieldsValid,
       address,
-      usePostalCode,
+      usePostalCode
     )
 
     const changedFieldsInvalid = {
@@ -425,7 +454,7 @@ describe('Address Validation:', () => {
     const result = validateChangedFields(
       changedFieldsInvalid,
       validatedAddress,
-      usePostalCode,
+      usePostalCode
     )
 
     expect(result.postalCode.valid).toBe(false)


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, there's a problem when validating optional fields that have options to be selected.

#### What problem is this solving?

When a field is not required and it has options to be selected (or, since it's optional, can be null), the app throws an error.
![image](https://user-images.githubusercontent.com/15948386/145262721-f58bb798-9bf0-4050-9379-ff75aabfc85b.png)

#### How should this be manually tested?

A test was added, but it can be accessed [here](https://dockfulladdress--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/?id=teste-endereco).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
