### PR TITLE
[LOGB2C-916] Add onLoadRules prop to AddressRules component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `onLoadRules` callback prop to `AddressRules` component.
+
 ## [4.12.1] - 2021-12-14
 
 ### Fixed

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -108,6 +108,10 @@ class AddressRules extends Component {
       }
     }
 
+    if (this.props.onLoadRules) {
+      this.props.onLoadRules({ rules })
+    }
+
     this.setState({ rules })
 
     return rules
@@ -144,6 +148,8 @@ AddressRules.propTypes = {
   useGeolocation: PropTypes.bool,
   /** Whether to always use the default rules as fallback or not */
   useDefaultRulesAsFallback: PropTypes.bool,
+  /** Callback function when the address rules are loaded */
+  onLoadRules: PropTypes.func,
 }
 
 export default AddressRules

--- a/react/AddressRules.test.js
+++ b/react/AddressRules.test.js
@@ -22,6 +22,25 @@ describe('AddressRules', () => {
     expect(rules).toEqual(braRules)
   })
 
+  it('should call onLoadRules if passed', async () => {
+    const onLoadRules = jest.fn()
+
+    const instance = shallow(
+      <AddressRules
+        country="BRA"
+        fetch={(country) => import(`./country/${country}`)}
+        onLoadRules={onLoadRules}
+      >
+        <h1>It works!</h1>
+      </AddressRules>
+    ).instance()
+
+    const rules = await instance.componentDidMount()
+
+    expect(rules).toEqual(braRules)
+    expect(onLoadRules).toHaveBeenCalledWith({ rules })
+  })
+
   it('should render its children', async () => {
     const testId = 'foo'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

Now it's possible to have a callback called precisely when the country rules are loaded. This is useful when using the rules change to execute something, like validation, instead of having an effect, having a more semantic way of doing that.

#### How should this be manually tested?

[Workspace](https://dockfulladdress--logisticsqa.myvtex.com/admin/shipping-strategy/loading-dock/?id=teste-endereco)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/146046967-cb425664-a62e-49fc-b4a6-d8886eabbe7b.png)


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
