### PR TITLE
Patch/irq country config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Invalid address `field` name for `IRQ`.
 
 ## [3.22.0] - 2022-01-13
-
 ### Added
 - Address rules for Iraq.
 
 ## [3.21.1] - 2021-12-13
-
 ### Added
 - `address-form.geolocation.example.RUS` to all language files.
 

--- a/react/country/IRQ.js
+++ b/react/country/IRQ.js
@@ -65,7 +65,7 @@ export default {
       size: 'large',
     },
     {
-      name: 'region',
+      name: 'state',
       maxLength: 100,
       label: 'region',
       required: true,
@@ -86,12 +86,7 @@ export default {
       { delimiter: '+', name: 'number' },
       { delimiter: ', ', name: 'complement' },
     ],
-    [
-      { name: 'city' },
-      { delimiter: ' , ', name: 'state' },
-    ],
-    [
-      { name: 'postalCode' },
-    ],
+    [{ name: 'city' }, { delimiter: ' , ', name: 'state' }],
+    [{ name: 'postalCode' }],
   ],
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

The aim of this PR is to change an invalid address `field` name for country `IRQ`. 
Since we use the field names to dynamically create `i18n` ids for translation purposes, this invalid field name would prevent this app from working properly in `IRQ` accounts.

<!--- Describe your changes in detail. -->

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
