### PR TITLE
Fix Russia country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+-Russia country rules.
+
 ## [3.22.3] - 2022-01-20
 
 ### Changed

--- a/react/country/RUS.js
+++ b/react/country/RUS.js
@@ -308,7 +308,6 @@ export default {
     },
     {
       name: 'number',
-      hidden: true,
       maxLength: 750,
       label: 'number',
       required: true,


### PR DESCRIPTION
Fix Russia country rules to correct crashing behavior in the checkout, as a variable was set as obligatory but had been kept as hidden.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
