### PR TITLE
Add required flag to IND postalCode field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add required flag to India's postal code field.
 
 ## [3.24.0] - 2022-02-15
 

--- a/react/country/IND.js
+++ b/react/country/IND.js
@@ -2,9 +2,7 @@ import { getOneLevel, getTwoLevels } from '../transforms/addressFieldsOptions'
 import { POSTAL_CODE } from '../constants'
 
 const countryData = {
-  'Andaman and Nicobar Islands': [
-    'Port Blair'
-  ],
+  'Andaman and Nicobar Islands': ['Port Blair'],
   'Andhra Pradesh': [
     'Adoni',
     'Amaravati',
@@ -27,9 +25,7 @@ const countryData = {
     'Vizianagaram',
     'Yemmiganur',
   ],
-  'Arunachal Pradesh': [
-    'Itanagar',
-  ],
+  'Arunachal Pradesh': ['Itanagar'],
   Assam: [
     'Dhuburi',
     'Dibrugarh',
@@ -72,9 +68,7 @@ const countryData = {
     'Sitamarhi',
     'Siwan',
   ],
-  Chandigarh: [
-    'Chandigarh',
-  ],
+  Chandigarh: ['Chandigarh'],
   Chhattisgarh: [
     'Ambikapur',
     'Bhilai',
@@ -85,19 +79,9 @@ const countryData = {
     'Raipur',
     'Rajnandgaon',
   ],
-  'Dadra and Nagar Haveli and Daman and Diu': [
-    'Daman',
-    'Diu',
-    'Silvassa',
-  ],
-  Delhi: [
-    'Delhi',
-    'New Delhi',
-  ],
-  Goa: [
-    'Madgaon',
-    'Panaji',
-  ],
+  'Dadra and Nagar Haveli and Daman and Diu': ['Daman', 'Diu', 'Silvassa'],
+  Delhi: ['Delhi', 'New Delhi'],
+  Goa: ['Madgaon', 'Panaji'],
   Gujarat: [
     'Ahmadabad',
     'Amreli',
@@ -226,10 +210,7 @@ const countryData = {
     'Thiruvananthapuram',
     'Thrissur',
   ],
-  Ladakh: [
-    'Kargil',
-    'Leh',
-  ],
+  Ladakh: ['Kargil', 'Leh'],
   'Madhya Pradesh': [
     'Balaghat',
     'Barwani',
@@ -322,24 +303,10 @@ const countryData = {
     'Wardha',
     'Yavatmal',
   ],
-  Manipur: [
-    'Imphal',
-  ],
-  Meghalaya: [
-    'Cherrapunji',
-    'Shillong',
-  ],
-  Mizoram: [
-    'Aizawl',
-    'Lunglei',
-  ],
-  Nagaland: [
-    'Kohima',
-    'Mon',
-    'Phek',
-    'Wokha',
-    'Zunheboto',
-  ],
+  Manipur: ['Imphal'],
+  Meghalaya: ['Cherrapunji', 'Shillong'],
+  Mizoram: ['Aizawl', 'Lunglei'],
+  Nagaland: ['Kohima', 'Mon', 'Phek', 'Wokha', 'Zunheboto'],
   Odisha: [
     'Balangir',
     'Baleshwar',
@@ -357,12 +324,7 @@ const countryData = {
     'Sambalpur',
     'Udayagiri',
   ],
-  Puducherry: [
-    'Karaikal',
-    'Mahe',
-    'Puducherry',
-    'Yanam',
-  ],
+  Puducherry: ['Karaikal', 'Mahe', 'Puducherry', 'Yanam'],
   Punjab: [
     'Amritsar',
     'Batala',
@@ -417,12 +379,7 @@ const countryData = {
     'Tonk',
     'Udaipur',
   ],
-  Sikkim: [
-    'Gangtok',
-    'Gyalshing',
-    'Lachung',
-    'Mangan',
-  ],
+  Sikkim: ['Gangtok', 'Gyalshing', 'Lachung', 'Mangan'],
   'Tamil Nadu': [
     'Arcot',
     'Chengalpattu',
@@ -463,9 +420,7 @@ const countryData = {
     'Sangareddi',
     'Warangal',
   ],
-  Tripura: [
-    'Agartala',
-  ],
+  Tripura: ['Agartala'],
   'Uttar Pradesh': [
     'Agra',
     'Aligarh',
@@ -580,7 +535,8 @@ const countryData = {
     'Tamluk',
     'Titagarh',
   ],
-}  
+}
+
 export default {
   country: 'IND',
   abbr: 'IN',
@@ -596,6 +552,7 @@ export default {
     {
       name: 'postalCode',
       maxLength: 50,
+      required: true,
       label: 'postalCode',
       size: 'small',
       regex: '^[1-9][0-9]{5}$',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates India's postalCode field to be required.

#### What problem is this solving?

Fixes an issue where clearing the postalCode field would fill the address form with the previously entered address.

#### How should this be manually tested?

You can access [this workspace](https://lucas--whirlpoolindia.myvtex.com/checkout/cart/add/?sku=130&qty=1&seller=1&sc=1).

You can use the following phone number `12345 67890`, and the document is optional in the profile form. The postal code you can use `400001`.

#### Screenshots or example usage

https://user-images.githubusercontent.com/10223856/154961962-1307b4f4-f0dd-457d-8df4-89a2f21d0759.mov

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
