### PR TITLE
Add Placeholder for ZAF market

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
-- Added support for ZAF locale
+### Added
+- Support for ZAF locale
 
 ## [3.24.6] - 2022-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.24.6] -
+### Changed
 - Added support for ZAF locale
 
 ## [3.24.6] - 2022-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.24.6] -
+- Added support for ZAF locale
+
 ## [3.24.6] - 2022-03-21
 
 ### Fixed

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "مثال: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "مثال: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "مثال: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Eg: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "هذا الحقل مطلوب.",
   "address-form.error.ERROR_POSTAL_CODE": "رمز بريدي غير صالح.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "عنوان غير صالح.",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Напр.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Напр.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Напр: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Hanp: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Това поле е задължително.",
   "address-form.error.ERROR_POSTAL_CODE": "Невалиден пощенски код.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Невалиден адрес.",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Per exemple: Surinamestraat, 27, Amsterdam",
   "address-form.geolocation.example.POL": "Per exemple: Ulica Twarda, 3, Szczecin",
   "address-form.geolocation.example.RUS": "Per exemple: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Per exemple: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Aquest camp és obligatori.",
   "address-form.error.ERROR_POSTAL_CODE": "Codi postal no vàlid.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Adreça no vàlida.",

--- a/messages/context.json
+++ b/messages/context.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Eg: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Eg: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Eg: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Eg: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "This field is required.",
   "address-form.error.ERROR_POSTAL_CODE": "Invalid postal code.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Invalid address.",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Např. Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Např. Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Např. Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Např. 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Toto pole je povinné.",
   "address-form.error.ERROR_POSTAL_CODE": "Neplatné PSČ.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Neplatná adresa.",

--- a/messages/da.json
+++ b/messages/da.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "F.eks.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "F.eks.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "F.eks.: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "F.eks.: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Dette felt er påkrævet.",
   "address-form.error.ERROR_POSTAL_CODE": "Ugyldigt postnummer.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ugyldig adresse.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "z. B.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "z. B.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "z. B.: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "z. B.: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Dieses Feld muss ausgefüllt werden.",
   "address-form.error.ERROR_POSTAL_CODE": "Ungültige Postleitzahl.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ungültige Adresse.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Π.χ.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Π.χ.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Π.χ.: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Π.χ.: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Αυτό το πεδίο είναι υποχρεωτικό.",
   "address-form.error.ERROR_POSTAL_CODE": "Άκυρος ταχυδρομικός κώδικας.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Άκυρη διεύθυνση.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Eg: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Eg: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Eg: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Eg: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "This field is required.",
   "address-form.error.ERROR_POSTAL_CODE": "Invalid postal code.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Invalid address.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Ej: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Ej: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Ej: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Ej: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Este campo es obligatorio.",
   "address-form.error.ERROR_POSTAL_CODE": "Código postal no válido.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Dirección no válida.",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Esim.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Esim.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Esim.: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Esim: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Tämä kenttä on pakollinen.",
   "address-form.error.ERROR_POSTAL_CODE": "Virheellinen postinumero.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Virheellinen osoite.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Ex : Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Ex : Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Ex : Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Ex: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Ce champ est obligatoire.",
   "address-form.error.ERROR_POSTAL_CODE": "Code postal non valable.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Adresse non valable.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Es: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Es: Ulica Twarda 3, Stettino",
   "address-form.geolocation.example.RUS": "Es: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Es: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Questo campo è obbligatorio.",
   "address-form.error.ERROR_POSTAL_CODE": "Codice postale non valido.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Indirizzo non valido.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "예: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "예: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "예: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "예: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "해당 입력란은 필수 입력 사항입니다.",
   "address-form.error.ERROR_POSTAL_CODE": "잘못된 우편번호입니다.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "잘못된 주소입니다.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Bijv: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Bijv: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Bijv: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Bijv: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Dit veld is verplicht.",
   "address-form.error.ERROR_POSTAL_CODE": "Ongeldige postcode.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ongeldig adres.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Np. Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Np. Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Np. Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "NP: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "To pole jest wymagane.",
   "address-form.error.ERROR_POSTAL_CODE": "Nieprawidłowy kod pocztowy.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Nieprawidłowy adres.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Ex: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Ex: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Ex: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Ex: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Campo obrigatório.",
   "address-form.error.ERROR_POSTAL_CODE": "Código postal inválido.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Endereço inválido.",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Exemplu: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Exemplu: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Exemplu: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Exemplu: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Acest câmp este obligatoriu.",
   "address-form.error.ERROR_POSTAL_CODE": "Cod poștal invalid.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Adresă invalidă.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Например: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Например: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Например: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Например: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Необходимо заполнить данное поле.",
   "address-form.error.ERROR_POSTAL_CODE": "Недействительный почтовый индекс.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Недействительный адрес.",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Napr.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Napr.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Napr.: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Napr.: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Toto pole je povinné.",
   "address-form.error.ERROR_POSTAL_CODE": "Neplatné PSČ.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Neplatná adresa.",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Npr.: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Npr.: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Npr.: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Npr: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "To polje je obvezno.",
   "address-form.error.ERROR_POSTAL_CODE": "Neveljavna poštna koda.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Neveljaven naslov.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Ex: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Ex: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Ex: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Ex: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Fältet krävs",
   "address-form.error.ERROR_POSTAL_CODE": "Ogiltig postnummer.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ogiltig adress.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -30,6 +30,7 @@
   "address-form.geolocation.example.NLD": "Eg: Surinamestraat 27, Amsterdam",
   "address-form.geolocation.example.POL": "Eg: Ulica Twarda 3, Szczecin",
   "address-form.geolocation.example.RUS": "Eg: Арбат, 3 Москва",
+  "address-form.geolocation.example.ZAF": "Eg: 234  Brickfield Rd, Salt River, Cape Town, 7501, South Africa",
   "address-form.error.ERROR_EMPTY_FIELD": "Це поле необхідно заповнити.",
   "address-form.error.ERROR_POSTAL_CODE": "Недійсний поштовий індекс.",
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Недійсна адреса.",


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
Added the placeholder message for ZAF locale for TFG client in south africa
address-form.geolocation.example.ZAF

#### What problem is this solving?
add placeholder on checkout for ZAF because checkout is loading the "default" locale in some cases.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Please deploy the app to
 https://checkoutnocustom--thefoschini.myvtex.com/checkout/cart/add/?sku=1&qty=1&seller=1&sc=1
 
#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
