### PR TITLE
Fix Arabic translation and Russia country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Arabic translation and Russia country rules for two-levels postal code.
+
 ## [3.24.7] - 2022-03-22
 
 ### Added

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -51,7 +51,7 @@
   "address-form.field.reference": "بالقرب من",
   "address-form.field.district": "الدائرة",
   "address-form.field.neighborhood": "الجِوار",
-  "address-form.field.commercial": "العنوان التجاري",
+  "address-form.field.commercial": "تجاري",
   "address-form.field.city": "المدينة",
   "address-form.field.town": "المدينة",
   "address-form.field.locality": "المقاطعة",

--- a/react/country/RUS.js
+++ b/react/country/RUS.js
@@ -1,6 +1,6 @@
-import { ONE_LEVEL } from '../constants'
-import { firstLevelPostalCodes } from '../transforms/postalCodes'
-import { getOneLevel } from '../transforms/addressFieldsOptions.js'
+import { TWO_LEVELS } from '../constants'
+import { secondLevelPostalCodes } from '../transforms/postalCodes'
+import { getOneLevel, getTwoLevels } from '../transforms/addressFieldsOptions'
 
 const countryDataRaw = {
   'Республика Адыгея': {
@@ -278,9 +278,9 @@ const countryData = capitalizeStatename(countryDataRaw)
 export default {
   country: 'RUS',
   abbr: 'RU',
-  postalCodeFrom: ONE_LEVEL,
-  postalCodeLevels: ['state'],
-  firstLevelPostalCodes: firstLevelPostalCodes(countryData),
+  postalCodeFrom: TWO_LEVELS,
+  postalCodeLevels: ['state', 'city'],
+  secondLevelPostalCodes: secondLevelPostalCodes(countryData),
   fields: [
     {
       hidden: true,
@@ -347,6 +347,9 @@ export default {
       label: 'city',
       required: true,
       size: 'large',
+      level: 2,
+      basedOn: 'state',
+      optionsMap: getTwoLevels(countryData),
     },
     {
       name: 'receiverName',


### PR DESCRIPTION
Fix Arabic translation and Russia country rules for two-levels postal code.