### PR TITLE
Complement field as mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Singapore address rules, `complement field` as mandatory
+
 ## [3.25.0] - 2022-04-07
 
 ### Added

--- a/react/country/SGP.js
+++ b/react/country/SGP.js
@@ -43,6 +43,7 @@ export default {
       maxLength: 750,
       label: 'addressLine2',
       size: 'xlarge',
+      required: true,
     },
     {
       hidden: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Added complement field as mandatory in Singapore address file. [LOC-8096](https://vtex-dev.atlassian.net/browse/LOC-8096)

#### How should this be manually tested?

https://camila--kasasg.myvtex.com/checkout#/shipping


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
