### PR TITLE
[COC-107]: Fix number validation blocking NLD and BEL's users from proceeding to payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `NLD` and `BEL` users not able to proceed to payment due to missing `number` geolocation field.
+
 ## [3.25.1] - 2022-04-14
 
 ### Changed

--- a/react/country/BEL.js
+++ b/react/country/BEL.js
@@ -72,6 +72,13 @@ export default {
       required: false,
     },
 
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],

--- a/react/country/NLD.js
+++ b/react/country/NLD.js
@@ -72,6 +72,13 @@ export default {
       required: false,
     },
 
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],


### PR DESCRIPTION
#### What is the purpose of this pull request?

Users from these countries were not able to proceed to the payment step on the geolocation mode. This happens because the `number` geolocation field is missing. And the declaration of this field is needed in order to bypass some validations.

So, in order to fix that, this PR adds the missing field to the geolocation rules, even though we are declaring it as not required.

For more details check the [Escalation thread on slack](https://vtex.slack.com/archives/C017NPK8U86/p1649069725151009).

<!--- Describe your changes in detail. -->

#### How should this be manually tested?

- [Add items to cart](https://jeff2--yamamay.myvtex.com/checkout/cart/add/?sku=7325&qty=1&seller=1&sc=13)
- Type a random email
- Fill the profile information with whatever you want (there's no validation for telephone and document) 
- Proceed to shipping
- Use the address `Burgemeester Oudlaan 50`
- You should be able to proceed to the payment step

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/166565249-55fa46ef-49c2-43f1-92f6-ed6538675005.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
