### PR TITLE
Fix: Prevent address autocompletion by postal code when the country is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Address autocompletion by postal code with `null` country value.
+
 ## [3.25.2] - 2022-05-11
 
 ### Fixed

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -79,10 +79,12 @@ class AddressContainer extends Component {
         address.postalCode.value !== validatedAddress.postalCode.value
 
       const isValidPostalCode = validatedAddress.postalCode.valid === true
+      const isValidCountry = validatedAddress.country?.value
       const shouldAutoComplete =
         rules.postalCodeFrom === POSTAL_CODE &&
         diffFromPrev &&
         isValidPostalCode &&
+        isValidCountry &&
         postalCodeField &&
         postalCodeField.postalCodeAPI
 

--- a/react/AddressContainer.test.js
+++ b/react/AddressContainer.test.js
@@ -228,5 +228,31 @@ describe('AddressContainer', () => {
       // Assert
       expect(postalCodeAutoCompleteAddress).not.toHaveBeenCalled()
     })
+
+    it('should not auto complete postal code when country value is not valid', () => {
+      // Arrange
+      const handleAddressChange = jest.fn()
+      const wrapper = mount(
+        <AddressContainer
+          cors
+          accountName={accountName}
+          address={address}
+          onChangeAddress={handleAddressChange}
+          rules={usePostalCode}
+        >
+          <PostalCodeGetter rules={usePostalCode} />
+        </AddressContainer>
+      )
+
+      // Act
+      const { onChangeAddress } = descendToChild(wrapper).props()
+
+      onChangeAddress({
+        postalCode: { value: '22231000' },
+      })
+
+      // Assert
+      expect(postalCodeAutoCompleteAddress).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR prevents from trying to do an address autocompletion by postal code when the country is `null`.

We did a similar attempt before (See https://github.com/vtex/address-form/pull/274 and https://github.com/vtex/address-form/pull/279), so I think we should take a close look into this possible deploy. 

<!--- Describe your changes in detail. -->

#### How should this be manually tested?

I don't know how to exactly simulate the scenario where this happens, but it still happens 😅 . It usually happens when you _**quickly**_ paste a postal code on shipping-preview input, for example.

But you can confirm the problem mentioned on [279](https://github.com/vtex/address-form/pull/279) doesn't happen, by doing:
- Use this [cart link](https://jeff--vtexgame1.myvtex.com/checkout/cart/add/?sku=289&qty=1&seller=1&sc=1)
- Proceed to Checkout
- Use a first purchase email
- Fill profile info 
- At Omnishipping, use the postal code `22210060`
- Proceed to payment by filling the `number` input
- Select Boleto as the payment method
- Finish the purchase

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
