### PR TITLE
ci(benstalk): add iam role

### DIFF
--- a/.vtex/deployment.json
+++ b/.vtex/deployment.json
@@ -12,12 +12,19 @@
       "image": "053131491888.dkr.ecr.us-east-1.amazonaws.com/awsbuild/ubuntu/node:10",
       "vpc": {
         "id": "vpc-d4f109b1",
-        "subnets": ["subnet-955f63d3", "subnet-245f030c", "subnet-0e35267a"],
-        "securityGroups": ["sg-c84127b3"]
+        "subnets": [
+          "subnet-955f63d3",
+          "subnet-245f030c",
+          "subnet-0e35267a"
+        ],
+        "securityGroups": [
+          "sg-c84127b3"
+        ]
       }
     },
     "service": {
-      "type": "front"
+      "type": "front",
+      "iamInstanceProfile": "BeanstalkRole_address-form"
     },
     "tags": [
       {


### PR DESCRIPTION

# Setting application's IAM Role

Hello, how are you? I am creating this pull request to change your application, so each service defined in `.vtex/deployment.json` has their own IAM role.
This is the initial step for creating a role for our beanstalk applications, here at VTEX. The next step is to edit each role, so that each service has the least privilege that it needs to run.

## What is an IAM Role?

An IAM role defines what privileges an app has when interacting with cloud resources (such as S3 objects, SQS queues, SNS objects and so on).
Today, every app receives a general role, which has far more privileges than it needs.

## Where is my role defined?

Each service has it own roles:
- [address-form](https://github.com/vtex/application-roles/blob/main/roles/beanstalk-roles/address-form/address-form/role.yaml)

We have documented the process for creating/editing this file [here](https://internal-docs.vtex.com/Security%20%26%20Privacy/Documents/creating-roles/).

## I have more questions

You can contact us at `#trusthub` in Slack.
