### PR TITLE
Add AUS, IDN and NZL country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Indonesia ('IDN') country rules.
+
 ## [3.26.3] - 2022-07-22
 ### Added
 - Added German complement to rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Indonesia ('IDN') country rules.
+- Australia ('AUS'), Indonesia ('IDN') and New Zealand ('NZL') country rules.
 
 ## [3.26.3] - 2022-07-22
 ### Added

--- a/react/countries.ts
+++ b/react/countries.ts
@@ -2,6 +2,7 @@
 import defaultRules from './country/default'
 import ARE from './country/ARE'
 import ARG from './country/ARG'
+import AUS from './country/AUS'
 import BOL from './country/BOL'
 import BRA from './country/BRA'
 import CAN from './country/CAN'
@@ -16,6 +17,7 @@ import IDN from './country/IDN'
 import IND from './country/IND'
 import KOR from './country/KOR'
 import MEX from './country/MEX'
+import NZL from './country/NZL'
 import PER from './country/PER'
 import PRT from './country/PRT'
 import PRY from './country/PRY'
@@ -31,6 +33,7 @@ export default {
   defaultRules,
   ARE,
   ARG,
+  AUS,
   BOL,
   BRA,
   CAN,
@@ -45,6 +48,7 @@ export default {
   IND,
   KOR,
   MEX,
+  NZL,
   PER,
   PRT,
   PRY,

--- a/react/countries.ts
+++ b/react/countries.ts
@@ -12,6 +12,7 @@ import ESP from './country/ESP'
 import FRA from './country/FRA'
 import GBR from './country/GBR'
 import GTM from './country/GTM'
+import IDN from './country/IDN'
 import IND from './country/IND'
 import KOR from './country/KOR'
 import MEX from './country/MEX'
@@ -40,6 +41,7 @@ export default {
   FRA,
   GBR,
   GTM,
+  IDN,
   IND,
   KOR,
   MEX,

--- a/react/country/AUS.ts
+++ b/react/country/AUS.ts
@@ -1,0 +1,136 @@
+import { POSTAL_CODE } from '../constants'
+import type { PostalCodeRules } from '../types/rules'
+
+const rules: PostalCodeRules = {
+  country: 'AUS',
+  abbr: 'AU',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      label: 'postalCode',
+      maxLength: 4,
+      required: true,
+      mask: '9999',
+      regex: /^\d{4}$/,
+      postalCodeAPI: false,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [{ name: 'complement' }, { delimiter: ' ', name: 'street'}],
+    [
+      { name: 'city' },
+      { delimiter: ', ', name: 'state' },
+      { delimiter: ' ', name: 'postalCode' },
+    ],
+  ],
+}
+
+export default rules

--- a/react/country/IDN.js
+++ b/react/country/IDN.js
@@ -1,0 +1,155 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'IDN',
+  abbr: 'ID',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 50,
+      label: 'postalCode',
+      size: 'small',
+      autoComplete: 'nope',
+      postalCodeAPI: false,
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
+    ],
+    [
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
+    ],
+  ],
+}

--- a/react/country/IDN.ts
+++ b/react/country/IDN.ts
@@ -1,6 +1,7 @@
 import { POSTAL_CODE } from '../constants'
+import type { PostalCodeRules } from '../types/rules'
 
-export default {
+const rules: PostalCodeRules = {
   country: 'IDN',
   abbr: 'ID',
   postalCodeFrom: POSTAL_CODE,
@@ -153,3 +154,5 @@ export default {
     ],
   ],
 }
+
+export default rules

--- a/react/country/NZL.ts
+++ b/react/country/NZL.ts
@@ -1,0 +1,136 @@
+import { POSTAL_CODE } from '../constants'
+import type { PostalCodeRules } from '../types/rules'
+
+const rules: PostalCodeRules = {
+  country: 'NZL',
+  abbr: 'NZ',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      label: 'postalCode',
+      maxLength: 4,
+      required: true,
+      mask: '9999',
+      regex: /^\d{4}$/,
+      postalCodeAPI: false,
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
+    street: { valueIn: 'long_name', types: ['route'] },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [{ name: 'complement' }, { delimiter: ' ', name: 'street'}],
+    [
+      { name: 'city' },
+      { delimiter: ', ', name: 'state' },
+      { delimiter: ' ', name: 'postalCode' },
+    ],
+  ],
+}
+
+export default rules


### PR DESCRIPTION
Add Australia ('AUS'), Indonesia ('IDN') and New Zealand ('NZL') country rules. Tracked by tasks [LOC-8769](https://vtex-dev.atlassian.net/browse/LOC-8769) and [LOC-8768](https://vtex-dev.atlassian.net/browse/LOC-8768).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
