### PR TITLE
Fix regex for detecting module not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Regex for detecting "module not found" error.
 
 ## [3.26.0] - 2022-07-19
 ### Changed

--- a/react/AddressRules.tsx
+++ b/react/AddressRules.tsx
@@ -5,7 +5,11 @@ import type { PostalCodeRules } from 'types/rules'
 import { RulesContext } from './addressRulesContext'
 import defaultRules from './country/default'
 
-const MODULE_NOT_FOUND_PATTERN = /Cannot find module '(.*)'(?: from '.*')/
+const pathSegment = '(?:\\.|\\.\\.|[\\w\\d\\s.-]+)'
+
+const MODULE_NOT_FOUND_PATTERN = new RegExp(
+  `Cannot find module '(${pathSegment}(?:(?:\\/|\\\\)${pathSegment})*)'`
+)
 
 const propTypes = {
   children: PropTypes.any.isRequired,

--- a/react/__tests__/AddressRules.test.tsx
+++ b/react/__tests__/AddressRules.test.tsx
@@ -9,6 +9,22 @@ import braRules from '../country/BRA'
 import { getField } from '../selectors/fields'
 
 describe('AddressRules', () => {
+  let loadedRules: PostalCodeRules | null = null
+
+  const LoadedRulesComponent = () => {
+    loadedRules = useAddressRules()
+
+    if (loadedRules == null) {
+      return null
+    }
+
+    return <span>loaded rules</span>
+  }
+
+  beforeEach(() => {
+    loadedRules = null
+  })
+
   it('should load the defined rules', async () => {
     let rules: PostalCodeRules | null = null
 
@@ -37,30 +53,18 @@ describe('AddressRules', () => {
       .spyOn(global.console, 'warn')
       .mockImplementation(() => {})
 
-    let rules: PostalCodeRules | null = null
-
-    const MyComponent = () => {
-      rules = useAddressRules()
-
-      if (rules == null) {
-        return null
-      }
-
-      return <span>loaded rules</span>
-    }
-
     render(
       <AddressRules
         country="XXX"
         fetch={(country) => import(`../country/${country}`)}
       >
-        <MyComponent />
+        <LoadedRulesComponent />
       </AddressRules>
     )
 
     await screen.findByText('loaded rules')
 
-    expect(rules).toEqual(defaultRules)
+    expect(loadedRules).toEqual(defaultRules)
     expect(warnSpy).toHaveBeenCalledWith(
       "Couldn't load rules for country XXX, using default rules instead."
     )
@@ -71,18 +75,6 @@ describe('AddressRules', () => {
       .spyOn(global.console, 'warn')
       .mockImplementation(() => {})
 
-    let rules: PostalCodeRules | null = null
-
-    const MyComponent = () => {
-      rules = useAddressRules()
-
-      if (rules == null) {
-        return null
-      }
-
-      return <span>loaded rules</span>
-    }
-
     render(
       <AddressRules
         country="BRA"
@@ -90,15 +82,34 @@ describe('AddressRules', () => {
           Promise.reject(new Error(`Cannot find module '${country}'`))
         }
       >
-        <MyComponent />
+        <LoadedRulesComponent />
       </AddressRules>
     )
 
     await screen.findByText('loaded rules')
 
-    expect(rules).toEqual(defaultRules)
+    expect(loadedRules).toEqual(defaultRules)
     expect(warnSpy).toHaveBeenCalledWith(
       "Couldn't load rules for country BRA, using default rules instead."
+    )
+  })
+
+  it('should use default rules with IO fetching when country does not exist', async () => {
+    const warnSpy = jest
+      .spyOn(global.console, 'warn')
+      .mockImplementation(() => {})
+
+    render(
+      <AddressRules country="XXX" shouldUseIOFetching>
+        <LoadedRulesComponent />
+      </AddressRules>
+    )
+
+    await screen.findByText('loaded rules')
+
+    expect(loadedRules).toEqual(defaultRules)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Couldn't load rules for country XXX, using default rules instead."
     )
   })
 

--- a/react/__tests__/AddressRules.test.tsx
+++ b/react/__tests__/AddressRules.test.tsx
@@ -66,6 +66,42 @@ describe('AddressRules', () => {
     )
   })
 
+  it('should use default rules when error message matches module not found', async () => {
+    const warnSpy = jest
+      .spyOn(global.console, 'warn')
+      .mockImplementation(() => {})
+
+    let rules: PostalCodeRules | null = null
+
+    const MyComponent = () => {
+      rules = useAddressRules()
+
+      if (rules == null) {
+        return null
+      }
+
+      return <span>loaded rules</span>
+    }
+
+    render(
+      <AddressRules
+        country="BRA"
+        fetch={(country) =>
+          Promise.reject(new Error(`Cannot find module '${country}'`))
+        }
+      >
+        <MyComponent />
+      </AddressRules>
+    )
+
+    await screen.findByText('loaded rules')
+
+    expect(rules).toEqual(defaultRules)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Couldn't load rules for country BRA, using default rules instead."
+    )
+  })
+
   it('should merge geolocation field rules with default field rules', async () => {
     let rules: PostalCodeRules | null = null
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the regex used for detecting a "module not found" error when importing a country rule file.

#### What problem is this solving?

This fixes an issue in production with stores that relies on this behavior to 
load the default rules (the country of the store does not have specific rules). 
In production, the message for this error is formatted as follows:

```
Cannot find module './country/HND'
```

And since it does not have the `from './AddressRules.js'` portion, it failed to 
match the regex and didn't load the default rules.

#### How should this be manually tested?

You can test in [this workspace]. I also added an unit test with the error 
message from production, to assert we won't create regressions.

In the workspace you can check if the shipping module is being loaded, that's it

[this workspace]: https://lucas--paizhn.myvtex.com/checkout

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
