### PR TITLE
Fix logic for address mismatch log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Logic for log of mismatched addresses.
 
 ## [3.26.1] - 2022-07-20
 ### Fixed

--- a/react/selectors/fields.ts
+++ b/react/selectors/fields.ts
@@ -30,7 +30,7 @@ function isGeolocationRule(rule: Rule): rule is GeolocationRule {
   return !('name' in rule)
 }
 
-export function getField(fieldName: Fields, rules: Rules) {
+export function getField(fieldName: Fields, rules: Rules): Rule | undefined {
   if ('fields' in rules) {
     return rules.fields.find((field) => field.name === fieldName)
   }

--- a/react/validateAddress.ts
+++ b/react/validateAddress.ts
@@ -381,31 +381,20 @@ function logIfGeolocationAddressMismatchExists<FieldName extends Fields>(
   address: AddressWithValidation,
   rules: PostalCodeRules
 ) {
-  if (name === 'city') {
-    const stateField = getField('state', rules) as PostalCodeFieldRule
+  const field = getField(name, rules)
 
-    const stateResult = validateOptions(
-      address.state.value,
-      stateField,
+  if (field && 'basedOn' in field && field.basedOn) {
+    const { basedOn } = field
+    const basedOnField = getField(basedOn, rules) as PostalCodeFieldRule
+
+    const result = validateOptions(
+      address[basedOn].value,
+      basedOnField,
       address,
       rules
     )
 
-    if (!stateResult.valid) {
-      return
-    }
-  }
-
-  if (name === 'neighborhood') {
-    const cityField = getField('city', rules) as PostalCodeFieldRule
-    const cityResult = validateOptions(
-      address.city.value,
-      cityField,
-      address,
-      rules
-    )
-
-    if (!cityResult.valid) {
+    if (!result.valid) {
       return
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR updates the `logIfGeolocationAddressMismatchExists` function to use the 
`basedOn` property on the rule fields, instead of hard-coding the "upper" field 
for `state`,`city` and `neighborhood`

#### What problem is this solving?

This fixes an issue (notably on `CHL` country rules), where the neighborhood 
field is based on the state instead of the most common case of city. This 
didn't cause any issues on production because the `getListOfOptions` function 
only throws in development (don't ask me why :shrug:).

This is just a bit annoying because if you are trying to debug an address using 
these country rules and using a development workspace you will see an error 
that blocks the flow which never occurs in production.

#### How should this be manually tested?

I added a few unit tests to cover this scenario.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
