### PR TITLE
Feature/german complement added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added German complement to rules
 
 ## [3.26.2] - 2022-07-22
 ### Fixed

--- a/react/country/DEU.ts
+++ b/react/country/DEU.ts
@@ -121,6 +121,11 @@ const rules: PostalCodeRules = {
       types: ['neighborhood'],
     },
 
+    complement: {
+      valueIn: 'long_name',
+      types: ['subpremise'],
+    },
+
     state: {
       valueIn: 'long_name',
       types: ['administrative_area_level_1'],


### PR DESCRIPTION
#### What is the purpose of this pull request?
Germany does not have this value mapped to the checkout-ui-custom Address From. By adding this complement we can utilize it to map it to the correct field and autocomplete the missing value. 

#### What problem is this solving?
- This removed the missing complement field from being autocompleted

#### How should this be manually tested?
- You can manually test [here](https://checkoutrules--sandboxusdev.myvtex.com/)

#### Screenshots or example usage
![Image 2022-07-22 at 11 44 34 a m](https://user-images.githubusercontent.com/11176519/180486041-47214dcb-8cfd-4ea1-ad1d-5e1698c4a10d.jpg)


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
