### PR TITLE
Bugfix/spain address rules change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Address rules for SPAIN
 
 ## [3.26.4] - 2022-07-22
 

--- a/react/country/ESP.ts
+++ b/react/country/ESP.ts
@@ -161,12 +161,12 @@ const rules: PostalCodeRules = {
 
     state: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_1'],
+      types: ['administrative_area_level_2'],
     },
 
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['locality'],
     },
 
     receiverName: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- This PR changes the address rules for Spain
- This is so the `province` is autocompleted in the `checkout-ui-custom` form

#### What problem is this solving?
- This issue solved the `CustomAddresForm` in the checkout ui custom app (filling in the province field)

#### How should this be manually tested?
- This can be tested on [this environment](https://beto--sandboxusdev.myvtex.com/)

#### Screenshots or example usage
![Image 2022-07-26 at 4 12 00 p m](https://user-images.githubusercontent.com/11176519/181112832-a5182813-6e46-41fd-96ac-48d6f9c0d4e0.jpg)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
