### PR TITLE
[CHECKOUTUI-98] Update city country rule for germany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.26.8] - 2022-08-10
 ### Fixed
+- Fixed city type being retrieved from GMaps API
+
+### Fixed
 - Invalidate whitespace-only required fields.
 
 ## [3.26.7] - 2022-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [3.26.8] - 2022-08-10
 ### Fixed
 - Fixed city type being retrieved from GMaps API
+
+## [3.26.8] - 2022-08-10
 
 ### Fixed
 - Invalidate whitespace-only required fields.

--- a/react/country/DEU.ts
+++ b/react/country/DEU.ts
@@ -133,7 +133,7 @@ const rules: PostalCodeRules = {
 
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['locality', 'political'],
     },
 
     receiverName: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Changed the Address rules for Germany, this is currently bringing the incorrect city for this country

#### What problem is this solving?
- Showing the correct city for German country

#### How should this be manually tested?
- You can test it on [this environment](https://alberto--sandboxusdev.myvtex.com/)
- Add a product to the checkout
- Change country in address form to Germany
- Use this Address: `Schubertstraße 3/1, 71154 Nufringen, Germany`
- This should bring back this city `Nufringen`

#### Screenshots or example usage
- ![Image 2022-08-23 at 6 39 29 p m](https://user-images.githubusercontent.com/11176519/186284667-7e1e8652-e0c4-48ca-9e03-cf56ddce6ec6.jpg)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
