### PR TITLE
CHK-2030: Replace splunkevents-js with window.logSplunk call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace usage of `splunkevents-js` with `window.logSplunk`.
 
 ## [3.26.8] - 2022-08-10
 ### Fixed

--- a/react/package.json
+++ b/react/package.json
@@ -28,8 +28,7 @@
     "lodash": "^4.17.4",
     "msk": "^1.0.5",
     "react-intl": "^2.8.0",
-    "recompose": "^0.27.1",
-    "splunk-events": "^1.7.0"
+    "recompose": "^0.27.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1501,11 +1501,6 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.3.tgz#7731a9c2d4148f2f9bb53d718c56dc9e6afe5b3e"
   integrity sha512-07Ly+NsFDTvjNdvl5bLBA5oHeGIIHCKc7CniGuKnHrjvqcTPVqPEo4z6a8iYydZ0WvDA6ZA0fnhYrqCLbsm0+A==
 
-"@testing-library/user-event@^14.2.3":
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.3.tgz#7731a9c2d4148f2f9bb53d718c56dc9e6afe5b3e"
-  integrity sha512-07Ly+NsFDTvjNdvl5bLBA5oHeGIIHCKc7CniGuKnHrjvqcTPVqPEo4z6a8iYydZ0WvDA6ZA0fnhYrqCLbsm0+A==
-
 "@types/aria-query@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
@@ -6131,11 +6126,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-splunk-events@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/splunk-events/-/splunk-events-1.7.0.tgz#4400c2b224387e598806c8fb7e6e687cf9143fe4"
-  integrity sha512-OdqBiyE45GIYWWzeNZVcZHqvagRwBINy26+u2Iu2nWQYzPtD7HnL6hSgWzFXNBzRxdQuUQWeAKE58I6pvJ9xjA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removes the `splunk-events` dependency and update logging code to use `window.logSplunk`

#### What problem is this solving?

We are migrating away from using Splunk as our all-in-one solution for logs, metrics and KPIs.

This PR is one stepping stone in the path to use other more appropriate systems for our logs and metrics.

This will make all metrics logging code to use `window.logSplunk` (which is [declared in checkout-ui](https://github.com/vtex/vcs.checkout-ui/blob/master/src/script/splunk-logger.coffee#L20-L43)), which therefore will use `@vtex/diagnostics-web`.

#### How should this be manually tested?

You can use [this workspace](https://diagnosticsjs--vtexgame1.myvtex.com/checkout/cart/add?sku=289&qty=1&seller=1) and make sure that the logs are still being sent to Splunk. Also, you can use the beta environment to test using the Checkout UI beta which is already using diagnostics-js.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
