### PR TITLE
Enabling postalCode to SAU rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `SAU` to have **postalCode**
+
 
 ## [3.27.2] - 2022-09-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - `SAU` to have **postalCode**
+- `ARE` to have **postalCode**
 
 
 ## [3.27.2] - 2022-09-06

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.27.2",
+  "version": "3.27.3-beta.0",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/country/ARE.ts
+++ b/react/country/ARE.ts
@@ -14,7 +14,7 @@ const rules: PostalCodeRules = {
       size: 'medium',
     },
     {
-      hidden: true,
+      hidden: false,
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',

--- a/react/country/SAU.ts
+++ b/react/country/SAU.ts
@@ -14,7 +14,7 @@ const rules: PostalCodeRules = {
       size: 'medium',
     },
     {
-      hidden: true,
+      hidden: false,
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Making postalCode visible for Saudi Arabia and Emirates.
If the postalCode is not available, the shipping options can't be calculated from the cart
