### PR TITLE
[KI 415388] Some addresses autocompleted by Google are not able to be saved on My Account

### DIFF
--- a/react/AddressForm.js
+++ b/react/AddressForm.js
@@ -33,7 +33,7 @@ class AddressForm extends Component {
     } = this.props
 
     let fields = omitPostalCodeFields
-      ? filterPostalCodeFields(rules)
+      ? filterPostalCodeFields(rules, address)
       : rules.fields
 
     fields = omitAutoCompletedFields

--- a/react/InputFieldContainer.js
+++ b/react/InputFieldContainer.js
@@ -133,11 +133,15 @@ class InputFieldContainer extends Component {
       shouldShowNumberKeyboard,
     } = this.props
 
-    const _options =
+    let _options =
       options ||
       (hasOptions(field, address)
         ? getListOfOptions(field, address, rules)
         : undefined)
+    
+    if (field?.name === 'city' && _options?.length) {
+      _options = _options?.filter(({ label, value }) => value !== `${label}___000000`)
+    }
 
     const notApplicableProps =
       // the right side of the || is for lib consumers without the 'useGeolocation' flag

--- a/react/country/ROU.js
+++ b/react/country/ROU.js
@@ -3513,6 +3513,7 @@ const countryData = {
     Zizin: '507223',
   },
   Bucureşti: {
+    'Bucuresti': '000000',
     'Bucuresti (Sectorul 1)': '010000',
     'Bucuresti (Sectorul 2)': '020000',
     'Bucuresti (Sectorul 3)': '030000',

--- a/react/selectors/fields.js
+++ b/react/selectors/fields.js
@@ -165,7 +165,7 @@ function getFieldBasedOn(fieldName, rules) {
   return field ? field.name : null
 }
 
-export function filterPostalCodeFields(rules) {
+export function filterPostalCodeFields(rules, address) {
   switch (rules.postalCodeFrom) {
     case THREE_LEVELS:
       return filter(
@@ -184,7 +184,7 @@ export function filterPostalCodeFields(rules) {
       )
     default:
     case POSTAL_CODE:
-      return filter(rules.fields, ({ name }) => name !== 'postalCode')
+      return filter(rules.fields, ({ name }) => name !== 'postalCode' ? true : !address?.postalCode?.geolocationAutoCompleted)
   }
 }
 

--- a/react/validateAddress.js
+++ b/react/validateAddress.js
@@ -2,6 +2,7 @@ import reduce from 'lodash/reduce'
 import find from 'lodash/find'
 
 import { hasOptions, getField, getListOfOptions } from './selectors/fields'
+import cleanStr from './selectors/cleanStr'
 import { addFocusToNextInvalidField } from './transforms/address'
 import {
   EEMPTY,
@@ -146,8 +147,8 @@ const invalidGeoCoords = { valid: false, reason: EGEOCOORDS }
 const invalidPostalCode = { valid: false, reason: EPOSTALCODE }
 
 function valueInOptions(value, options) {
-  const normalizedValue = value.toLowerCase()
-  const normalizedOptions = options.map((option) => option.toLowerCase())
+  const normalizedValue = cleanStr(value)
+  const normalizedOptions = options.map((option) => cleanStr(option))
 
   return normalizedOptions.indexOf(normalizedValue) !== -1
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR is intended to solve the [KI 415388](https://vtexhelp.zendesk.com/agent/tickets/415388)

#### What problem is this solving?

For some countries Google Maps does not send the postal code when autocompleting an address, there was a filter where the postal code field was always hidden, now it validates if the postal code has been autocompleted by google, if not, the postal code input is rendered.

#### How should this be manually tested?

1. Go to: https://address--eobando.myvtex.com/account#/addresses/new
2. Login with any user (new or existing, no matter)
3. Select Mexico as a Country
4. In the google maps address input, enter the address: "Avenida Paseo de la Reforma"
![image](https://user-images.githubusercontent.com/26680887/214896802-82b21a0e-1e22-4cc2-8ea4-e40bd3eafcb1.png)

5. Now, you can see how the zip code field is rendered.

If you do the same test but without workspace (without the change), everything seems to be fine, but when you save, it simply does nothing, this is because the address is not valid, zip code is missing in the address.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/26680887/214897555-a10db649-d71e-4a4c-8fe5-f181f7c43640.png)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
