### PR TITLE
Fix AUS geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Geolocation implementation for Australia ('AUS').
+
 ## [3.29.1] - 2023-02-14
 ### Changed
 - Add the number field as hidden in France config file.

--- a/react/country/AUS.ts
+++ b/react/country/AUS.ts
@@ -95,7 +95,14 @@ const rules: PostalCodeRules = {
       notApplicable: true,
     },
 
-    street: { valueIn: 'long_name', types: ['route'] },
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+      handler: (address, googleAddress) => {
+        address.street = { value: (googleAddress as { name: string }).name }
+          return address
+      },
+    },
 
     neighborhood: {
       valueIn: 'long_name',


### PR DESCRIPTION
Fix geolocation implementation for Australia ('AUS'). Tracked in task [LOC-9610](https://vtex-dev.atlassian.net/browse/LOC-9610).

Test workspace: https://sheila--vtexgame1geo.myvtex.com/checkout/cart/add?sku=312&qty=1&seller=1&sc=2

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-9610]: https://vtex-dev.atlassian.net/browse/LOC-9610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ