### PR TITLE
Add number in France address config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add the number field as hidden in France config file.
 
 ## [3.29.0] - 2022-12-23
 ### Added

--- a/react/country/FRA.ts
+++ b/react/country/FRA.ts
@@ -31,6 +31,14 @@ const rules: PostalCodeRules = {
       size: 'xlarge',
     },
     {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'min',
+      autoComplete: 'nope',
+    },
+    {
       name: 'complement',
       maxLength: 750,
       label: 'addressLine2',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the number field to France config file as a `hidden` field. The change its motivated by a Store that needs the number field to complete the purchase. 

#### How should this be manually tested?

- Access https://withouttheme--casinofrqa.myvtex.com/checkout/cart/add/?sku=47049&qty=1&seller=1&sc=1
- Got to checkout 
- Proceed to shipping
- Add a France postal code (eg: 70123)
- Open Browser inspector
- Check if field with CSS class `ship-number` it's on DOM

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
