### PR TITLE
enable AUS zip code auto-fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Australia ('AUS') postal code auto-fill enable.
+
 ## [3.29.4] - 2023-03-23
 
 ### Added

--- a/react/country/AUS.ts
+++ b/react/country/AUS.ts
@@ -20,7 +20,7 @@ const rules: PostalCodeRules = {
       required: true,
       mask: '9999',
       regex: /^\d{4}$/,
-      postalCodeAPI: false,
+      postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable Australia postal code auto-fill in Checkout. It relates to [LOC-10195](https://vtex-dev.atlassian.net/browse/LOC-10195)

#### What problem is this solving?

The postal code autofill wasn't enabled.

#### How should this be manually tested?

https://localization--averee.myvtex.com/checkout/#/shipping.

You can use 02 12345567 to simulate a phone number and 3000, 3201, and 3123 for postal code entry.

#### Screenshots or example usage

![Screenshot 2023-03-23 at 09 54 37](https://user-images.githubusercontent.com/71647659/227211800-279bc6e3-c87e-4a6a-bfcb-1f5a5653507f.png)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-10195]: https://vtex-dev.atlassian.net/browse/LOC-10195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ