### PR TITLE
update AUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Australia ('AUS') postal code auto-fill API has been disabled to allow GAPI to perperly auto-fill.
+
 ## [3.29.6] - 2023-03-31
 
 ### Changed

--- a/react/country/AUS.ts
+++ b/react/country/AUS.ts
@@ -20,7 +20,7 @@ const rules: PostalCodeRules = {
       required: true,
       mask: '9999',
       regex: /^\d{4}$/,
-      postalCodeAPI: true,
+      postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',
     },


### PR DESCRIPTION
the postal code API overwrites the GAPI (google maps API) value. We need to deactivate the postalcode api and leave only the GAPI on.

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
