### PR TITLE
[Fix][OMS-4082][KI-1673] Remove options from AddressRules validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Filter optionsMap, valueOptions and options out from `AddressRules` geolocation validation.
+
 ## [4.17.2] - 2023-03-23
 
 ### Fixed
+
 - Australia ('AUS') postal code auto-fill enable.
 
 ## [4.17.1] - 2023-03-23
 
 ### Added
+
 - `Suburb` translation
 
 ## [4.17.0] - 2023-01-02
@@ -186,10 +192,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [4.7.3] - 2021-05-13
 
 ### Fixed
+
 - Ensure the `state` field is populate when user visits `addresses` inside their account for `RUS`.
+
 ## [4.7.2] - 2021-05-12
 
-### Fixed 
+### Fixed
 
 - `CHL` rules when filling data with Google Maps.
 

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -97,10 +97,12 @@ class AddressRules extends Component {
           if (rules.geolocation[field.name]) {
             // ignore unrelated props for the field
             // eslint-disable-next-line no-unused-vars
-            const { valueIn, types, handler, ...props } =
+            const { valueIn, types, handler, ...geolocationProps } =
               rules.geolocation[field.name]
 
-            return { ...field, ...props }
+            const { optionsMap, valueOptions, options, ...fieldProps } = field
+
+            return { ...fieldProps, ...geolocationProps }
           }
 
           return field


### PR DESCRIPTION
> Slack thread: https://vtex.slack.com/archives/C1FRE8V9A/p1680010951538169
> KI investigation document: https://docs.google.com/document/d/1HxyxtgwT7pvtv2Vzrz-gHEjhVNGPgYXtwt7VVZtseN8/edit#heading=h.22ulvli9avdm

#### What is the purpose of this pull request?

Remove options from AddressRules validation.

<!--- Describe your changes in detail. -->

#### What problem is this solving?



<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Visit those workspaces and try adding the following addresses:

> guatemala 600 belgrano, rosario

> Franklin D. Roosevelt 1312, Villa Madero, La Matanza

[Before](https://vtexgame1geo.myvtex.com/account#/addresses) vs [After](https://lucasio--vtexgame1geo.myvtex.com/account#/addresses)

#### Screenshots or example usage


https://user-images.githubusercontent.com/28812834/228628778-93cc9a7d-a5d3-429a-8f2e-0d6e6ee8c4f1.mov


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
