### PR TITLE
Add rules for Puerto Rico ('PRI').

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Rules for Puerto Rico ('PRI'). Same as USA, but with 'State' field pre-filled with 'PR'.
+
 ## [3.29.7] - 2023-04-04
 
 ### Fixed

--- a/react/country/PRI.ts
+++ b/react/country/PRI.ts
@@ -1,0 +1,143 @@
+import { POSTAL_CODE } from '../constants'
+import type { PostalCodeRules } from '../types/rules'
+
+const rules: PostalCodeRules = {
+  country: 'PRI',
+  abbr: 'PR',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    },
+    {
+      name: 'postalCode',
+      maxLength: 50,
+      fixedLabel: 'ZIP',
+      required: true,
+      mask: '99999',
+      regex: '^([\\d]{5}((-)?[\\d]{4})?)$',
+      postalCodeAPI: true,
+      forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      hidden: true,
+      size: 'large',
+      optionsPairs: [
+        { label: 'Puerto Rico', value: 'PR' },
+      ],
+      defaultValue: 'PR'
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      hidden: true,
+      defaultValue: 'N/A',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+      handler: (address, googleAddress) => {
+        address.street = { value: (googleAddress as { name: string }).name }
+
+        return address
+      },
+    },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+
+    state: {
+      valueIn: 'short_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [{ name: 'street' }, { delimiter: ', ', name: 'complement' }],
+    [
+      { name: 'city' },
+      { delimiter: ', ', name: 'state' },
+      { delimiter: ' ', name: 'postalCode' },
+    ],
+  ],
+}
+
+export default rules


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add rules for Puerto Rico ('PRI') as per [LOC-10275](https://vtex-dev.atlassian.net/browse/LOC-10275).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-10275]: https://vtex-dev.atlassian.net/browse/LOC-10275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ