### PR TITLE
rearrange address fields from GAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Australia ('AUS') address fields rearranged using GAPI.
+
 ## [4.18.0] - 2023-04-25
 
 ### Added

--- a/react/country/AUS.js
+++ b/react/country/AUS.js
@@ -109,13 +109,13 @@ export default {
     },
 
     state: {
-      valueIn: 'long_name',
+      valueIn: 'short_name',
       types: ['administrative_area_level_1'],
     },
 
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['locality', 'administrative_area_level_4'],
     },
 
     receiverName: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Rearrange the order of the address information that appears using GAPI.

#### What problem is this solving?

The order of the address information is wrong and not abbreviated
<img width="785" alt="Screenshot 2023-04-25 at 19 05 25" src="https://user-images.githubusercontent.com/71647659/234562964-be7048f4-aec1-411a-be8e-0e65bdbb7807.png">


#### How should this be manually tested?

https://camila2--averee.myvtex.com/checkout/#/shipping

#### Screenshots or example usage

<img width="1080" alt="Screenshot 2023-04-25 at 19 03 56" src="https://user-images.githubusercontent.com/71647659/234563028-619f086e-210e-43dd-bc06-72dcf6f888dc.png">

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
