### PR TITLE
CHK-1969 - CHK-1968 - Address review flow is removing essential address information and showing calculate shipping button for complete address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Number field discarded in geolocation mode for FRA
+- Number field discarded in geolocation mode for USA
+- Number field as required in geolocation mode for USA
 - Address being reviewed in the geolocation mode even for complete addresses.
 
 ## [3.31.0] - 2023-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Address review flow is removing essential address information.
+- Number field discarded in geolocation mode for FRA
 - Address being reviewed in the geolocation mode even for complete addresses.
 
 ## [3.31.0] - 2023-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Address review flow is removing essential address information.
+- Address being reviewed in the geolocation mode even for complete addresses.
 
 ## [3.31.0] - 2023-04-27
 

--- a/react/country/FRA.ts
+++ b/react/country/FRA.ts
@@ -81,6 +81,13 @@ const rules: PostalCodeRules = {
       required: false,
     },
 
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],

--- a/react/country/USA.ts
+++ b/react/country/USA.ts
@@ -157,6 +157,13 @@ const rules: PostalCodeRules = {
       required: false,
     },
 
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],

--- a/react/country/VEN.ts
+++ b/react/country/VEN.ts
@@ -298,6 +298,13 @@ const rules: PostalCodeRules = {
       types: ['street_number'],
     },
 
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+
     street: { valueIn: 'long_name', types: ['route'] },
 
     neighborhood: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix "Calculate Shipping" button working incorrectly by fixing [this](https://vtex-dev.atlassian.net/browse/CHK-1969) and [this](https://vtex-dev.atlassian.net/browse/CHK-1968) KIs.

#### What problem is this solving?

Fix the issue that the "Calculate Shipping" button was showing up even for full addresses, which caused 2 issues:

- It made it impossible for the user to proceed with the payment
- Caused some information to be lost when the user clicked on the "Calculate Shipping" button

This problem was happening in stores in France, United States and Venezuela, but it had already been fixed for stores in Brazil and Chile previously.

#### How should this be manually tested?

- Access https://evertonstrack--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
- Proceed to checkout 
- Use an email address of a user that does NOT exist (to avoid auto-completing the address)
- Fill Contact Information
- In the Shipping step, select `France` and enter the address `42000 Saint-Étienne`
- The address will change, the "Calculate shipping" button should not be displayed and it should be possible to proceed to the payment step as normal

**Test for USA:**
- In the Shipping step, select `United States of America` and enter the address `106 3rd Ave, New York`

**Test for VEN:**
- In the Shipping step, select `Venezuela` and enter the address `Caracas 1040, Distrito Capital`


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
