### PR TITLE
CHK-2464: Remove postal code rules when using geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Discard postal code rules when using geolocation mode in `AddressRules`.
 
 ## [3.31.1] - 2023-05-02
 ### Fixed

--- a/react/AddressRules.tsx
+++ b/react/AddressRules.tsx
@@ -125,6 +125,10 @@ class AddressRules extends Component<Props, State> {
               label: 'label' in field ? field.label : undefined,
               fixedLabel: 'fixedLabel' in field ? field.fixedLabel : undefined,
               required: false,
+              hidden: field.hidden,
+              mask: field.mask,
+              size: field.size,
+              forgottenURL: field.forgottenURL,
               ...geolocationProps,
             }
           }

--- a/react/AddressRules.tsx
+++ b/react/AddressRules.tsx
@@ -113,12 +113,20 @@ class AddressRules extends Component<Props, State> {
         fields: rules.fields.map((field) => {
           if (geolocationRules[field.name]) {
             // ignore unrelated props for the field
-            const { valueIn, types, handler, ...geolocationProps } =
-              geolocationRules[field.name]
+            const {
+              valueIn,
+              types,
+              handler,
+              ...geolocationProps
+            } = geolocationRules[field.name]
 
-            const { optionsMap, optionsPairs, options, ...fieldProps } = field
-
-            return { ...fieldProps, ...geolocationProps }
+            return {
+              name: field.name,
+              label: 'label' in field ? field.label : undefined,
+              fixedLabel: 'fixedLabel' in field ? field.fixedLabel : undefined,
+              required: false,
+              ...geolocationProps,
+            }
           }
 
           return field


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removes the merge of postal code rules in `AddressRules` when using geolocation mode.

#### What problem is this solving?

The motivation for this change is because when using geolocation rules, the postal code rules should be completely disregarded. So, in the current situation, when using geolocation mode some rules could still apply (such as a field being required in postal code mode, but the definition for `required` isn't in the geolocation rules, which should default to `false`, but the value of the postal code rule will be used).

#### How should this be manually tested?

I have executed the Checkout E2E Test Suite to cover this, you can also check in [this workspace](https://lucas--vtexgame1geo.myvtex.com/checkout) to see the changes.

Since this PR is for version 3.x, the issue in my account isn't fixed yet, but I'll open a PR for 4.x shortly.

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
