### PR TITLE
CHK-2464: [4.x] Remove postal code rules when using geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Discard postal code rules when using geolocation mode in `AddressRules`.
 
 ## [4.19.1] - 2023-05-02
 ### Fixed

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -107,6 +107,10 @@ class AddressRules extends Component {
               label: 'label' in field ? field.label : undefined,
               fixedLabel: 'fixedLabel' in field ? field.fixedLabel : undefined,
               required: false,
+              hidden: field.hidden,
+              mask: field.mask,
+              size: field.size,
+              forgottenURL: field.forgottenURL,
               ...geolocationProps,
             }
           }

--- a/react/AddressRules.js
+++ b/react/AddressRules.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types'
 import { RulesContext } from './addressRulesContext'
 import defaultRules from './country/default'
 
-const MODULE_NOT_FOUND_PATTERN =
-  /Cannot find module '\.\/[a-z]*\/?([A-z-]{1,7})'/
+const MODULE_NOT_FOUND_PATTERN = /Cannot find module '\.\/[a-z]*\/?([A-z-]{1,7})'/
 
 class AddressRules extends Component {
   constructor(props) {
@@ -96,13 +95,20 @@ class AddressRules extends Component {
         fields: rules.fields.map((field) => {
           if (rules.geolocation[field.name]) {
             // ignore unrelated props for the field
-            // eslint-disable-next-line no-unused-vars
-            const { valueIn, types, handler, ...geolocationProps } =
-              rules.geolocation[field.name]
+            const {
+              valueIn,
+              types,
+              handler,
+              ...geolocationProps
+            } = rules.geolocation[field.name]
 
-            const { optionsMap, valueOptions, options, ...fieldProps } = field
-
-            return { ...fieldProps, ...geolocationProps }
+            return {
+              name: field.name,
+              label: 'label' in field ? field.label : undefined,
+              fixedLabel: 'fixedLabel' in field ? field.fixedLabel : undefined,
+              required: false,
+              ...geolocationProps,
+            }
           }
 
           return field


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removes the merge of postal code rules in `AddressRules` when using geolocation mode.

#### What problem is this solving?

Same as #514, but for major 4.x which will include the fix for the apps using React Builder `3.x`.

This will effectively make the Checkout and My Account use the same validation logic, and guarantee consistency between the two apps.

#### How should this be manually tested?

Same as the PR linked above, you can check [this workspace](https://lucas--vtexgame1geo.myvtex.com/checkout) to see the changes.

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
