### PR TITLE
Update NZL.ts

### DIFF
--- a/react/country/NZL.ts
+++ b/react/country/NZL.ts
@@ -31,7 +31,7 @@ const rules: PostalCodeRules = {
       size: 'xlarge',
     },
     {
-      hidden: true,
+      hidden: false,
       name: 'number',
       maxLength: 750,
       label: 'number',


### PR DESCRIPTION
Fixing the street/house number not appearing on the address form after an address is selected. Customers are negatively impacted by the missing street number, assuming the order will not be delivered.

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

to replicate the scenario, access vineonline.myvtex.com, add any item to your cart and proceed to checkout. When asked for your address, start typing 48 Avalon Drive ... full address includes Forest Lake, 3200, Hamilton City, but we use Google Maps API for auto-complete. When you select the address, you will notice that the street number (48 in this case) goes missing. Hopefully with this deploy, that number will appear during the checkout process on the address form.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
