### PR TITLE
fix number not appearing using geolocation in NZL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Street field using geolocation in New Zealand (NZL) file.
+
 ## [4.21.1] - 2023-05-11
 ### Fixed
 - Discard postal code rules when using geolocation mode in `AddressRules`.

--- a/react/country/NZL.js
+++ b/react/country/NZL.js
@@ -98,8 +98,8 @@ export default {
       valueIn: 'long_name',
       types: ['route'],
       handler: (address, googleAddress) => {
-        address.street = { value: (googleAddress as { name: string }).name }
-          return address
+        address.street = { value: googleAddress.name }
+        return address
       },
     },
 

--- a/react/country/NZL.js
+++ b/react/country/NZL.js
@@ -94,7 +94,14 @@ export default {
       notApplicable: true,
     },
 
-    street: { valueIn: 'long_name', types: ['route'] },
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+      handler: (address, googleAddress) => {
+        address.street = { value: (googleAddress as { name: string }).name }
+          return address
+      },
+    },
 
     neighborhood: {
       valueIn: 'long_name',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixing the street/house number not appearing on the address form after an address is selected. Customers are negatively impacted by the missing street number, assuming the order will not be delivered.

It relates to closed PR https://github.com/vtex/address-form/pull/516 and https://github.com/vtex/address-form/pull/519

#### What problem is this solving?

to replicate the scenario, access vineonline.myvtex.com, add any item to your cart and proceed to checkout. When asked for your address, start typing 48 Avalon Drive ... full address includes Forest Lake, 3200, Hamilton City, but we use Google Maps API for auto-complete. When you select the address, you will notice that the street number (48 in this case) goes missing. Hopefully with this deploy, that number will appear during the checkout process on the address form.

#### How should this be manually tested?

https://localization--vineonline.myvtex.com/checkout/#/shipping

#### Screenshots or example usage

![Screenshot 2023-05-11 at 16 13 24](https://github.com/vtex/address-form/assets/71647659/7fa88a45-cba9-476c-abed-55f438853c41)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
