### PR TITLE
Fix missing notApplicable property in number field for geolocation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix missing`notApplicable` property in `number` field for geolocation mode
 
 ## [3.34.1] - 2023-05-24
 ### Fixed

--- a/react/geolocation/geolocationAutoCompleteAddress.js
+++ b/react/geolocation/geolocationAutoCompleteAddress.js
@@ -36,11 +36,8 @@ export default function geolocationAutoCompleteAddress(
     (updatedAddress) => addFocusToNextInvalidField(updatedAddress, rules),
   ])()
 
-  // unnecessary for 3.6.0+, but necessary for backward compatibility
-  // for lib consumers that don't pass `useGeolocation` to the `<AddressRules/>`
-  if (!rules._usingGeolocationRules) {
-    address = setNumberNotApplicable(address)
-  }
+  // Set notApplicable to number if property there is in geolocationRules
+  address = setNumberNotApplicable(address)
 
   return address
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix "Calculate Shipping" button working incorrectly by fixing [this](https://vtex-dev.atlassian.net/browse/CHK-1969) KI. The KI was fixes in [this PR](https://github.com/vtex/address-form/pull/512), but was reintroduced by [this](https://github.com/vtex/address-form/commit/4868c881212aaf0f614c981f2094bffa361578c3) and [this](https://github.com/vtex/omnishipping/commit/54eca885425397005974e5c596d480dadfcd31e2) changes 


#### What problem is this solving?

Fix the issue that the "Calculate Shipping" button was showing up even for full addresses, which caused 2 issues:

- It made it impossible for the user to proceed with the payment
- Caused some information to be lost when the user clicked on the "Calculate Shipping" button

This problem was happening in stores in France, United States and Venezuela, but it had already been fixed for stores in Brazil and Chile previously.

With the new changes, the `notApplicable` property was not being considered in number field for geolocation mode. This PR fixes that issue.

#### How should this be manually tested?

- Access account `vtexgame1geo` and workspace `chk1969` with VTEX IO CLI
- Link address-form to the workspace (`vtex link`)
- Access this workspace [Workspace](https://chk1969--vtexgame1geo.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2)
- Proceed to checkout 
- Use an email address of a user that does NOT exist (to avoid auto-completing the address)
- Fill Contact Information
- In the Shipping step, select `France` and enter the address `42000 Saint-Étienne`
- The address will change, the "Calculate shipping" button should not be displayed and it should be possible to proceed to the payment step as normal



#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
