### PR TITLE
Fix Uruguay geolocation city types order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Change Uruguay geolocation city types order for accuracy.
+
 ## [3.34.2] - 2023-06-13
 ### Fixed
 - Fix missing`notApplicable` property in `number` field for geolocation mode

--- a/react/country/URY.ts
+++ b/react/country/URY.ts
@@ -456,7 +456,7 @@ const rules: PostalCodeRules = {
 
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['locality', 'administrative_area_level_2'],
     },
 
     receiverName: {


### PR DESCRIPTION
Change Uruguay geolocation city types order for accuracy. Tracked in task [LOC-11437](https://vtex-dev.atlassian.net/browse/LOC-11437).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-11437]: https://vtex-dev.atlassian.net/browse/LOC-11437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ