### PR TITLE
Fix Uruguay geolocation city types order in my account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Change Uruguay geolocation city types order for accuracy.
+
 ## [4.22.0] - 2023-05-17
 
 ### Added

--- a/react/country/URY.js
+++ b/react/country/URY.js
@@ -455,7 +455,7 @@ export default {
 
     city: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_2', 'locality'],
+      types: ['locality', 'administrative_area_level_2'],
     },
 
     receiverName: {


### PR DESCRIPTION
Change Uruguay geolocation city types order for accuracy. Tracked in task [LOC-11437](https://vtex-dev.atlassian.net/browse/LOC-11437).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-11437]: https://vtex-dev.atlassian.net/browse/LOC-11437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ