### PR TITLE
Adding VIR country rules for address-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Virgin Islands (US) country rules.
+
 ## [4.22.2] - 2023-06-27
 
 ### Fixed

--- a/react/country/VIR.js
+++ b/react/country/VIR.js
@@ -94,6 +94,13 @@ export default {
       required: false,
     },
 
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
+    },
+
     street: {
       valueIn: 'long_name',
       types: ['route'],

--- a/react/country/VIR.js
+++ b/react/country/VIR.js
@@ -1,0 +1,141 @@
+import { POSTAL_CODE } from '../constants'
+
+export default {
+  country: 'VIR',
+  abbr: 'VI',
+  postalCodeFrom: POSTAL_CODE,
+  fields: [
+    {
+      hidden: true,
+      name: 'country',
+      maxLength: 100,
+      label: 'country',
+      size: 'medium',
+    }, 
+    {
+      name: 'postalCode',
+      maxLength: 50,
+      fixedLabel: 'ZIP',
+      required: true,
+      mask: '99999-9999',
+      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)-\d{0,4}$',
+      // Asserts zipcode starts with 008, then contains one of the local accepted area values, then followed by hyphen and 4 digits.
+      postalCodeAPI: true,
+      forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',
+      size: 'small',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      hidden: true,
+      defaultValue: 'N/A',
+      autoComplete: 'nope',
+    },
+    {
+      name: 'street',
+      label: 'addressLine1',
+      required: true,
+      size: 'xlarge',
+    },
+    {
+      name: 'complement',
+      maxLength: 750,
+      label: 'addressLine2',
+      size: 'xlarge',
+    },
+    {
+      hidden: false,
+      name: 'neighborhood',
+      maxLength: 100,
+      label: 'neighborhood',
+      size: 'large',
+    },
+    {
+      name: 'city',
+      maxLength: 100,
+      label: 'city',
+      required: true,
+      size: 'large',
+    },
+    {
+      name: 'state',
+      maxLength: 100,
+      label: 'state',
+      required: true,
+      hidden: true,
+      size: 'large',
+      optionsPairs: [
+        { label: 'Virgin Islands', value: 'USVI' },
+      ],
+      defaultValue: 'USVI'
+    },
+    {
+      hidden: true,
+      name: 'reference',
+      maxLength: 750,
+      label: 'reference',
+      size: 'xlarge',
+    },
+    {
+      name: 'receiverName',
+      elementName: 'receiver',
+      maxLength: 750,
+      label: 'receiverName',
+      size: 'xlarge',
+      required: true,
+    },
+  ],
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+      handler: (address, googleAddress) => {
+        address.street = { value: googleAddress.name }
+
+        return address
+      },
+    },
+
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+
+    state: {
+      valueIn: 'short_name',
+      types: ['administrative_area_level_1'],
+    },
+
+    city: {
+      valueIn: 'long_name',
+      types: ['locality'],
+    },
+
+    receiverName: {
+      required: true,
+    },
+  },
+  summary: [
+    [{ name: 'street' }, { delimiter: ', ', name: 'complement' }],
+    [
+      { name: 'city' },
+      { delimiter: ', ', name: 'state' },
+      { delimiter: ' ', name: 'postalCode' },
+    ],
+  ],
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

It relates to task [LOC-11085](https://vtex-dev.atlassian.net/browse/LOC-11085).

#### How should this be manually tested?
Test store: https://george--worldwidegolf.myvtex.com/?

#### Screenshots or example usage
![image](https://github.com/vtex/address-form/assets/106821144/2f0269b6-2ca5-4298-a136-94a96e1f66c2)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-11085]: https://vtex-dev.atlassian.net/browse/LOC-11085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ