### PR TITLE
Fix ECU postal code selection to use cities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ecuador postal code settings to be more granular and show the cities list during check-out.
+
 ## [4.22.2] - 2023-06-27
 
 ### Fixed

--- a/react/country/ECU.js
+++ b/react/country/ECU.js
@@ -1,5 +1,5 @@
-import { ONE_LEVEL } from '../constants'
-import { firstLevelPostalCodes } from '../transforms/postalCodes'
+import { TWO_LEVELS } from '../constants'
+import { secondLevelPostalCodes } from '../transforms/postalCodes'
 import { getOneLevel, getTwoLevels } from '../transforms/addressFieldsOptions'
 
 const countryData = {
@@ -1266,9 +1266,9 @@ const countryData = {
 export default {
   country: 'ECU',
   abbr: 'EC',
-  postalCodeFrom: ONE_LEVEL,
-  postalCodeLevels: ['state'],
-  firstLevelPostalCodes: firstLevelPostalCodes(countryData),
+  postalCodeFrom: TWO_LEVELS,
+  postalCodeLevels: ['state', 'city'],
+  secondLevelPostalCodes: secondLevelPostalCodes(countryData),
   fields: [
     {
       hidden: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Show the city list during check-out in Ecuador stores to allow for more granular shipping settings. Tracked in task [LOC-11656](https://vtex-dev.atlassian.net/browse/LOC-11656).

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-11656]: https://vtex-dev.atlassian.net/browse/LOC-11656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ