### PR TITLE
Vine patch 1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.34.4",
+  "version": "3.34.5",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/country/NZL.ts
+++ b/react/country/NZL.ts
@@ -130,10 +130,11 @@ const rules: PostalCodeRules = {
       required: true,
     },
   },
-  summary: [
+summary: [
     [{ name: 'complement' }, { delimiter: ' ', name: 'street' }],
     [
       { name: 'city' },
+      { delimiter: ', ', name: 'neighborhood' },
       { delimiter: ', ', name: 'state' },
       { delimiter: ' ', name: 'postalCode' },
     ],


### PR DESCRIPTION
#### What is the purpose of this pull request?

<added neighborhood to the GAPI-generated address at checkout.

#### What problem is this solving?

The suburb is mandatory in New Zealand. By adding it to the address format display, it solves a client request.

#### How should this be manually tested?

Clone the repo to VSCODE, login to localtest--vineoneline.myvtex.com, add the changes to the NZL.ts country file and change the manifest json app version, then link the app to the workspace. Proceed with placing an order and choose an address, for example 1020 .... (google maps auto-fill will do the rest). Notice the suburb is showing. 

Client is live, do not attempt this on the master workspace please.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
