### PR TITLE
Fix NZL geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- New Zealand geolocation to include neighborhood.
+
+### Fixed
+
 - Ecuador postal code settings to be more granular and show the cities list during check-out.
 
 ## [3.34.6] - 2023-08-24

--- a/react/country/NZL.ts
+++ b/react/country/NZL.ts
@@ -131,7 +131,10 @@ const rules: PostalCodeRules = {
     },
   },
   summary: [
-    [{ name: 'complement' }, { delimiter: ' ', name: 'street' }],
+    [{ name: 'complement' }, 
+     { delimiter: ' ', name: 'street' },
+     { delimiter: ' ', name: 'neighborhood' },
+    ],
     [
       { name: 'city' },
       { delimiter: ', ', name: 'state' },


### PR DESCRIPTION
Fixed New Zealand geolocation to include neighborhood. Tracked in task [LOC-12478](https://vtex-dev.atlassian.net/browse/LOC-12478).

#### How should this be manually tested?
https://sheilavtex--vineonline.myvtex.com/checkout/cart/add/?sku=1426&qty=3&seller=1&sc=1

#### Screenshots or example usage
![image](https://github.com/vtex/address-form/assets/26465317/11743713-4120-4653-9779-5148b07d9afa)

#### Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-12478]: https://vtex-dev.atlassian.net/browse/LOC-12478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ