### PR TITLE
Fix fields displayed for customers in the Netherlands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fields displayed for Netherlands customers, in order to better reflect the usual experience for shoppers in that country.
+
 ## [3.34.7] - 2023-10-09
 
 ### Fixed

--- a/react/country/ECU.ts
+++ b/react/country/ECU.ts
@@ -1279,7 +1279,7 @@ const rules: PostalCodeRules = {
   country: 'ECU',
   abbr: 'EC',
   postalCodeFrom: ONE_LEVEL,
-  postalCodeLevels: ['state'],
+  postalCodeLevels: ['city'],
   firstLevelPostalCodes: firstLevelPostalCodes(countryData),
   fields: [
     {

--- a/react/country/NLD.ts
+++ b/react/country/NLD.ts
@@ -31,6 +31,14 @@ const rules: PostalCodeRules = {
       size: 'xlarge',
     },
     {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
       name: 'complement',
       maxLength: 750,
       label: 'addressLine2',
@@ -41,13 +49,14 @@ const rules: PostalCodeRules = {
       maxLength: 100,
       label: 'city',
       required: true,
-      size: 'large',
+      size: 'xlarge',
     },
     {
+      hidden: true,
       name: 'state',
       maxLength: 100,
       label: 'department',
-      required: true,
+      required: false,
       size: 'large',
     },
     {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To provide the customary shopping experience for shoppers in the Netherlands. To that effect, this:
- hides the state field.
- shows the number field.

#### Screenshots or example usage
https://address--hunterdouglasnlqa.myvtex.com/checkout#/shipping

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
