### PR TITLE
 Fix fields displayed for customers in the Netherlands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fields displayed for Netherlands customers, in order to better reflect the usual experience for shoppers in that country.
+
 ## [4.22.4] - 2023-09-12
 
 ### Fixed

--- a/react/country/NLD.js
+++ b/react/country/NLD.js
@@ -30,6 +30,14 @@ export default {
       size: 'xlarge',
     },
     {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: true,
+      size: 'mini',
+      autoComplete: 'nope',
+    },
+    {
       name: 'complement',
       maxLength: 750,
       label: 'addressLine2',
@@ -40,13 +48,14 @@ export default {
       maxLength: 100,
       label: 'city',
       required: true,
-      size: 'large',
+      size: 'xlarge',
     },
     {
+      hidden: true,
       name: 'state',
       maxLength: 100,
       label: 'department',
-      required: true,
+      required: false,
       size: 'large',
     },
     {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To provide the customary shopping experience for shoppers in the Netherlands. To that effect, this:
- hides the state field.
- shows the number field.

#### Screenshots or example usage
https://address--hunterdouglasnlqa.myvtex.com/checkout#/shipping

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
