### PR TITLE
Fix NZL geolocation neighborhood comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fields displayed for Netherlands customers, in order to better reflect the usual experience for shoppers in that country.
+- New Zealand geolocation to format neighborhood.
+
+## [3.34.10] - 2023-10-12
+
+## [3.34.9] - 2023-10-12
+
+### Fixed
+
 - Made Number field not required for NLD customers.
 
 ## [3.34.8] - 2023-10-10
+
+### Fixed
+
+- Fields displayed for Netherlands customers, in order to better reflect the usual experience for shoppers in that country.
 
 ## [3.34.7] - 2023-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.34.10] - 2023-10-12
 
-## [3.34.9] - 2023-10-12
-
 ### Fixed
 
 - Made Number field not required for NLD customers.
+
+## [3.34.9] - 2023-10-12
 
 ## [3.34.8] - 2023-10-10
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.34.9",
+  "version": "3.34.10",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/country/NZL.ts
+++ b/react/country/NZL.ts
@@ -133,7 +133,7 @@ const rules: PostalCodeRules = {
   summary: [
     [{ name: 'complement' }, 
      { delimiter: ' ', name: 'street' },
-     { delimiter: ' ', name: 'neighborhood' },
+     { delimiter: ', ', name: 'neighborhood' },
     ],
     [
       { name: 'city' },


### PR DESCRIPTION
Fix to complement [this PR](https://github.com/vtex/address-form/pull/536), adding a comma for New Zealand geolocation between the address and the neighborhood. Tracked in task [LOC-12478](https://vtex-dev.atlassian.net/browse/LOC-12478).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-12478]: https://vtex-dev.atlassian.net/browse/LOC-12478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ