### PR TITLE
Change field prop for state in GBR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix prop for state in GBR
+
 ## [3.34.11] - 2023-10-18
 
 ### Fixed

--- a/react/country/GBR.ts
+++ b/react/country/GBR.ts
@@ -128,7 +128,10 @@ const rules: PostalCodeRules = {
 
     state: {
       valueIn: 'long_name',
-      types: ['administrative_area_level_1'],
+      types: [
+        'postal_town',
+        'administrative_area_level_1'
+      ],
     },
 
     city: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the state selection for england

#### What problem is this solving?

Geolocation from google change and currently `administrative_area_level_1` for GBR now returns the country instead of the state. The first selection was added.

![image](https://github.com/vtex/address-form/assets/25616893/2092294d-812c-442e-854c-9fca07051e0d)


#### How should this be manually tested?

app linked:
<img width="357" alt="image" src="https://github.com/vtex/address-form/assets/25616893/66e61267-b5ff-45e5-9535-57a0dbbfd3ae">

currently:
<img width="251" alt="image" src="https://github.com/vtex/address-form/assets/25616893/6568103e-a68b-45eb-a466-340ca4f3ed34">


#### Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
