### PR TITLE
Fix Belgium country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Belgium ('BEL') country rules.
+
 ## [3.34.11] - 2023-10-18
 
 ### Fixed

--- a/react/country/BEL.ts
+++ b/react/country/BEL.ts
@@ -31,6 +31,13 @@ const rules: PostalCodeRules = {
       size: 'xlarge',
     },
     {
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      required: false,
+      size: 'mini',
+    },
+    {
       name: 'complement',
       maxLength: 750,
       label: 'addressLine2',
@@ -41,13 +48,14 @@ const rules: PostalCodeRules = {
       maxLength: 100,
       label: 'city',
       required: true,
-      size: 'large',
+      size: 'xlarge',
     },
     {
+      hidden: true,
       name: 'state',
       maxLength: 100,
       label: 'department',
-      required: true,
+      required: false,
       size: 'large',
     },
     {


### PR DESCRIPTION
Fix Belgium country rules to hide department field and include number field. Tracked in task [LOC-12820](https://vtex-dev.atlassian.net/browse/LOC-12820).

#### How should this be manually tested?
https://sheilavtex--motorolabenl.myvtex.com/checkout/#/shipping

#### Screenshots or example usage
Before:
![Pasted image 20231117105827](https://github.com/vtex/address-form/assets/26465317/6c23269c-28ad-4f58-a1e9-c2a803133b33)
After:
![Pasted image 20231117111323](https://github.com/vtex/address-form/assets/26465317/062bb214-cd7c-4391-b713-2be9f224fb5e)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-12820]: https://vtex-dev.atlassian.net/browse/LOC-12820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ