### PR TITLE
Fix Netherlands country rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Belgium ('BEL') country rules.
+- Netherlands ('NDL')  country rules.
 
 ## [3.34.11] - 2023-10-18
 

--- a/react/country/NLD.ts
+++ b/react/country/NLD.ts
@@ -36,7 +36,6 @@ const rules: PostalCodeRules = {
       label: 'number',
       required: false,
       size: 'mini',
-      autoComplete: 'nope',
     },
     {
       name: 'complement',


### PR DESCRIPTION
Fix Netherlands country rules to fix number autocomplete. Tracked in task [LOC-12820](https://vtex-dev.atlassian.net/browse/LOC-12820).

#### How should this be manually tested?
https://sheilavtex--hunterdouglasnlqa.myvtex.com/checkout#/shipping

#### Screenshots or example usage
Before:
![Pasted image 20231117120518](https://github.com/vtex/address-form/assets/26465317/73e154f0-bcf2-48a4-a7a3-4d5132e1ef72)

After:
![Pasted image 20231117120818](https://github.com/vtex/address-form/assets/26465317/65f3ca6c-8394-4403-9d0c-019b09f7ffbd)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-12820]: https://vtex-dev.atlassian.net/browse/LOC-12820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ