### PR TITLE
Fix Netherlands ('NLD') country rules to show number in address summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Netherlands ('NLD')  country rules to show number in address summary.
+
 ## [4.22.7] - 2024-01-24
 
 ### Added

--- a/react/country/NLD.js
+++ b/react/country/NLD.js
@@ -106,8 +106,8 @@ export default {
     },
   },
   summary: [
+    [{ name: 'street' }, { delimiter: ' ', name: 'number' }],
     [{ name: 'complement' }],
-    [{ name: 'street' }],
     [{ name: 'postalCode' }, { delimiter: ' ', name: 'city' }],
   ],
 }


### PR DESCRIPTION
#### What problem is this solving?

Previously, addresses in the Netherlands would not show a number when viewing its summary.
![Untitled](https://github.com/vtex/address-form/assets/100872772/322b03c3-4718-4d50-97b9-255ceca64758)

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
