### PR TITLE
Fix MLT postal code validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.35.4] - 2024-05-06
+
 ### Fixed
 
 - Malta postal code validation.
@@ -1548,9 +1550,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **`AddressSubmitter`** component and tests
 
 
-[Unreleased]: https://github.com/vtex/address-form/compare/v3.35.3...HEAD
+[Unreleased]: https://github.com/vtex/address-form/compare/v3.35.4...HEAD
 [3.34.6]: https://github.com/vtex/address-form/compare/v3.34.5...v3.34.6
 [3.34.5]: https://github.com/vtex/address-form/compare/v3.34.4...v3.34.5
+[3.35.4]: https://github.com/vtex/address-form/compare/v3.35.3...v3.35.4
 [3.35.3]: https://github.com/vtex/address-form/compare/v3.35.2...v3.35.3
 [3.35.2]: https://github.com/vtex/address-form/compare/v3.35.1...v3.35.2
 [3.35.1]: https://github.com/address-form//compare/v3.35.0...v3.35.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Malta postal code validation.
+
 ## [3.35.3] - 2024-04-26
 
 ## [3.35.2] - 2024-04-25

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.35.3",
+  "version": "3.35.4",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/country/MLT.ts
+++ b/react/country/MLT.ts
@@ -19,7 +19,7 @@ const rules: PostalCodeRules = {
       fixedLabel: 'Post code',
       required: true,
       mask: 'AAA 999',
-      regex: '^[a-zA-Z]{2,3}\d{4}$',
+      regex: '^[a-zA-Z]{2,3}\s?\d{4}$',
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',


### PR DESCRIPTION
#### What is the purpose of this pull request?

It relates to the task [LOC-14346](https://vtex-dev.atlassian.net/browse/LOC-14346) and the PR #559. It fixes the MLT postal code validation, checking for a blank space in between the characters.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-14346]: https://vtex-dev.atlassian.net/browse/LOC-14346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ