### PR TITLE
Fix MLT postal code validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.23.1] - 2024-05-06
+
 ### Fixed
 
 - Malta postal code validation.
@@ -904,5 +906,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **`AddressSubmitter`** component and tests
 
 
-[Unreleased]: https://github.com/vtex/address-form/compare/v4.23.0...HEAD
+[Unreleased]: https://github.com/vtex/address-form/compare/v4.23.1...HEAD
+[4.23.1]: https://github.com/vtex/address-form/compare/v4.23.0...v4.23.1
 [4.23.0]: https://github.com/vtex/address-form/compare/v4.22.8...v4.23.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Malta postal code validation.
+
 ## [4.23.0] - 2024-04-26
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "4.23.0",
+  "version": "4.23.1",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/country/MLT.js
+++ b/react/country/MLT.js
@@ -18,7 +18,7 @@ export default {
       fixedLabel: 'Post code',
       required: true,
       mask: 'AAA 999',
-      regex: '^[a-zA-Z]{2,3}\d{4}$',
+      regex: '^[a-zA-Z]{2,3}\s?\d{4}$',
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',


### PR DESCRIPTION
#### What is the purpose of this pull request?

It relates to the task [LOC-14346](https://vtex-dev.atlassian.net/browse/LOC-14346) and the PR https://github.com/vtex/address-form/pull/560. It fixes the MLT postal code validation, checking for a blank space in between the characters.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-14346]: https://vtex-dev.atlassian.net/browse/LOC-14346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ