### PR TITLE
Add Guatemala city

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+### Fixed
+
+- New city ('Guatemala Zona 25') in Guatemala.
+
 ## [4.24.1] - 2024-05-29
 
 ### Fixed

--- a/react/country/GTM.js
+++ b/react/country/GTM.js
@@ -153,6 +153,7 @@ const countryData = {
     'Guatemala Zona 18': '1018',
     'Guatemala Zona 19': '1019',
     'Guatemala Zona 21': '1021',
+    'Guatemala Zona 25': '1025',
     'Mixco (sin zona)': '1057',
     'Mixco Zona 1': '105701',
     'Mixco Zona 2': '105702',


### PR DESCRIPTION
Add Guatemala city ('Guatemala Zona 25'). Tracked in task [LOC-14854](https://vtex-dev.atlassian.net/browse/LOC-14854). Connected to [PR #584](https://github.com/vtex/address-form/pull/584).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-14854]: https://vtex-dev.atlassian.net/browse/LOC-14854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ