### PR TITLE
Remove hidden value for postalCode

### DIFF
--- a/react/country/ARE.ts
+++ b/react/country/ARE.ts
@@ -14,7 +14,6 @@ const rules: PostalCodeRules = {
       size: 'medium',
     },
     {
-      hidden: true,
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',


### PR DESCRIPTION
Remove hidden value for postalCode, so the field is shown in the Checkout UI

#### What is the purpose of this pull request?

This change will make the postal code input to be shown in the Chekout UI.

#### What problem is this solving?

Before:
![image](https://github.com/vtex/address-form/assets/90935861/008a9972-b115-47a2-92f9-637c0d6d8815)

After:
![image](https://github.com/vtex/address-form/assets/90935861/13b98b65-39ff-4061-b75b-0c9755a6fc91)

#### How should this be manually tested?
https://ki312132--vtexgame1clean.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
Select United Arab Emirates 

#### Types of changes

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
