### PR TITLE
Remove hidden value for postalCode v4

### DIFF
--- a/react/country/ARE.js
+++ b/react/country/ARE.js
@@ -13,7 +13,6 @@ export default {
       size: 'medium',
     },
     {
-      hidden: true,
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',


### PR DESCRIPTION
Remove hidden value for postalCode, so the field is shown in the Checkout UI

What is the purpose of this pull request?
This change will make the postal code input to be shown in the Chekout UI.

What problem is this solving?
Before:
image

After:
image

How should this be manually tested?
https://ki312132--vtexgame1clean.myvtex.com/checkout/cart/add/?sku=312&qty=1&seller=1&sc=2
Select United Arab Emirates

Types of changes
[ X ] Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to change)
 Requires change to documentation, which has been updated accordingly.