### PR TITLE
Add SAU rule + fix ARE validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the validations rules for Saudi Arabia.
+
+- Enable autocomplete postal code from reference field for ARE [[KI#312132](https://vtexhelp.zendesk.com/agent/tickets/312132)].
+
+## [4.24.4] - 2024-07-05
+
 ## [4.24.3] - 2024-06-06
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "4.24.3",
+  "version": "4.24.4",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "عنوان غير صالح.",
   "address-form.error.generic": "حقل غير صالح.",
   "address-form.field.addressQuery": "العنوان",
+  "address-form.field.emirates": "إمارات",
   "address-form.field.notApplicable": "غير متاح",
   "address-form.field.noNumber": "بدون أرقام",
   "address-form.field.country": "البلد",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Невалиден адрес.",
   "address-form.error.generic": "Невалидно поле.",
   "address-form.field.addressQuery": "Адрес",
+  "address-form.field.emirates": "إمارات",
   "address-form.field.notApplicable": "Няма",
   "address-form.field.noNumber": "Няма номер",
   "address-form.field.country": "Държава",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Adreça no vàlida.",
   "address-form.error.generic": "Camp no vàlid.",
   "address-form.field.addressQuery": "Adreça",
+  "address-form.field.emirates": "Emirats",
   "address-form.field.notApplicable": "No escau",
   "address-form.field.noNumber": "Sense número",
   "address-form.field.country": "País",

--- a/messages/context.json
+++ b/messages/context.json
@@ -35,6 +35,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Invalid address.",
   "address-form.error.generic": "Invalid field.",
   "address-form.field.addressQuery": "Address",
+  "address-form.field.emirates": "Emirates",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "No number",
   "address-form.field.country": "Country",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Neplatná adresa.",
   "address-form.error.generic": "Neplatné pole.",
   "address-form.field.addressQuery": "Adresa",
+  "address-form.field.emirates": "Emiráty",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "Žádné číslo",
   "address-form.field.country": "Země",

--- a/messages/da.json
+++ b/messages/da.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ugyldig adresse.",
   "address-form.error.generic": "Ugyldigt felt.",
   "address-form.field.addressQuery": "Adresse",
+  "address-form.field.emirates": "Emiraterne",
   "address-form.field.notApplicable": "Ikke tilgængelig",
   "address-form.field.noNumber": "Intet nummer",
   "address-form.field.country": "Land",

--- a/messages/de.json
+++ b/messages/de.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ungültige Adresse.",
   "address-form.error.generic": "Ungültiges Feld.",
   "address-form.field.addressQuery": "Adresse",
+  "address-form.field.emirates": "Emirate",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "Keine Nummer",
   "address-form.field.country": "Land",

--- a/messages/el.json
+++ b/messages/el.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Άκυρη διεύθυνση.",
   "address-form.error.generic": "Άκυρο πεδίο.",
   "address-form.field.addressQuery": "Διεύθυνση",
+  "address-form.field.emirates": "Ηνωμένα Αραβικά Εμιράτα",
   "address-form.field.notApplicable": "Κ/Α",
   "address-form.field.noNumber": "Δεν υπάρχει αριθμός",
   "address-form.field.country": "Χώρα",

--- a/messages/en.json
+++ b/messages/en.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Invalid address.",
   "address-form.error.generic": "Invalid field.",
   "address-form.field.addressQuery": "Address",
+  "address-form.field.emirates": "Emirates",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "No number",
   "address-form.field.country": "Country",

--- a/messages/es.json
+++ b/messages/es.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Dirección inválida.",
   "address-form.error.generic": "Campo inválido.",
   "address-form.field.addressQuery": "Dirección",
+  "address-form.field.emirates": "Emiratos",
   "address-form.field.notApplicable": "S/N",
   "address-form.field.noNumber": "Sin número",
   "address-form.field.country": "País",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Virheellinen osoite.",
   "address-form.error.generic": "Virheellinen kenttä.",
   "address-form.field.addressQuery": "Osoite",
+  "address-form.field.emirates": "Emiraatit",
   "address-form.field.notApplicable": "–",
   "address-form.field.noNumber": "Ei numeroa",
   "address-form.field.country": "Maa",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Adresse non valable.",
   "address-form.error.generic": "Champ non valable.",
   "address-form.field.addressQuery": "Adresse",
+  "address-form.field.emirates": "Émirats",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "Pas de numéro",
   "address-form.field.country": "Pays",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -67,6 +67,7 @@
     "address-form.error.ERROR_GOOGLE_ADDRESS": "Érvénytelen cím.",
     "address-form.error.generic": "Érvénytelen mező.",
     "address-form.field.addressQuery": "Cím",
+    "address-form.field.emirates": "Emirátusok",
     "address-form.field.notApplicable": "Nem elérhető",
     "address-form.field.noNumber": "Nincs szám",
     "address-form.field.country": "Ország",

--- a/messages/id.json
+++ b/messages/id.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Alamat tidak valid.",
   "address-form.error.generic": "Bidang tidak valid.",
   "address-form.field.addressQuery": "Alamat",
+  "address-form.field.emirates": "Emirat",
   "address-form.field.notApplicable": "Tidak Ada",
   "address-form.field.noNumber": "Tidak ada angka",
   "address-form.field.country": "Negara",

--- a/messages/it.json
+++ b/messages/it.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Indirizzo non valido.",
   "address-form.error.generic": "Campo non valido.",
   "address-form.field.addressQuery": "Indirizzo",
+  "address-form.field.emirates": "Emirati",
   "address-form.field.notApplicable": "N/D",
   "address-form.field.noNumber": "Nessun numero",
   "address-form.field.country": "Nazione",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "잘못된 주소입니다.",
   "address-form.error.generic": "잘못된 필드입니다.",
   "address-form.field.addressQuery": "주소",
+  "address-form.field.emirates": "아랍에미리트",
   "address-form.field.notApplicable": "해당 없음",
   "address-form.field.noNumber": "번호 없음",
   "address-form.field.country": "국가",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ongeldig adres.",
   "address-form.error.generic": "Ongeldig veld.",
   "address-form.field.addressQuery": "Adres",
+  "address-form.field.emirates": "Emiraten",
   "address-form.field.notApplicable": "NVT",
   "address-form.field.noNumber": "Geen nummer",
   "address-form.field.country": "Land",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Nieprawidłowy adres.",
   "address-form.error.generic": "Nieprawidłowe pole.",
   "address-form.field.addressQuery": "Adres",
+  "address-form.field.emirates": "Emiraty",
   "address-form.field.notApplicable": "B/D",
   "address-form.field.noNumber": "Brak numeru",
   "address-form.field.country": "Kraj",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Endereço inválido.",
   "address-form.error.generic": "Campo inválido.",
   "address-form.field.addressQuery": "Endereço",
+  "address-form.field.emirates": "Emirados",
   "address-form.field.notApplicable": "S/N",
   "address-form.field.noNumber": "Sem número",
   "address-form.field.country": "País",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Adresă invalidă.",
   "address-form.error.generic": "Câmp invalid.",
   "address-form.field.addressQuery": "Adresă",
+  "address-form.field.emirates": "Emiratele Arabe Unite",
   "address-form.field.notApplicable": "Nu se aplică",
   "address-form.field.noNumber": "Fără număr",
   "address-form.field.country": "Țara",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Недействительный адрес.",
   "address-form.error.generic": "Недействительное поле.",
   "address-form.field.addressQuery": "Название улицы",
+  "address-form.field.emirates": "Эмираты",
   "address-form.field.notApplicable": "Нет",
   "address-form.field.noNumber": "Без номера",
   "address-form.field.country": "Страна",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Neplatná adresa.",
   "address-form.error.generic": "Neplatné pole.",
   "address-form.field.addressQuery": "Adresa",
+  "address-form.field.emirates": "Emiráty",
   "address-form.field.notApplicable": "Nevzťahuje sa",
   "address-form.field.noNumber": "Žiadne číslo",
   "address-form.field.country": "Krajina",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Neveljaven naslov.",
   "address-form.error.generic": "Neveljavno polje.",
   "address-form.field.addressQuery": "Naslov",
+  "address-form.field.emirates": "Emirati",
   "address-form.field.notApplicable": "Ni na voljo",
   "address-form.field.noNumber": "Ni števila",
   "address-form.field.country": "Država",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Ogiltig adress.",
   "address-form.error.generic": "Ogiltigt fält.",
   "address-form.field.addressQuery": "Adress",
+  "address-form.field.emirates": "Förenade Arabemiraten",
   "address-form.field.notApplicable": "Ej tillgängligt",
   "address-form.field.noNumber": "Inga nummer",
   "address-form.field.country": "Land",

--- a/messages/th.json
+++ b/messages/th.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "ที่อยู่ไม่ถูกต้อง",
   "address-form.error.generic": "ฟิลด์ข้อมูลไม่ถูกต้อง",
   "address-form.field.addressQuery": "ที่อยู่",
+  "address-form.field.emirates": "อาหรับเอมิเรตส์",
   "address-form.field.notApplicable": "N/A",
   "address-form.field.noNumber": "ไม่มีเลขที่",
   "address-form.field.country": "ประเทศ",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -67,6 +67,7 @@
   "address-form.error.ERROR_GOOGLE_ADDRESS": "Недійсна адреса.",
   "address-form.error.generic": "Недійсне значення поля.",
   "address-form.field.addressQuery": "Адреса",
+  "address-form.field.emirates": "Емірати",
   "address-form.field.notApplicable": "Не доступно",
   "address-form.field.noNumber": "Номер відсутній",
   "address-form.field.country": "Країна",

--- a/react/country/SAU.js
+++ b/react/country/SAU.js
@@ -1,23 +1,9 @@
-import { firstLevelPostalCodes } from '../transforms/postalCodes'
-import { getOneLevel } from '../transforms/addressFieldsOptions'
-import { POSTAL_CODE ,  ONE_LEVEL} from '../constants'
-
-const emiratesPostalCodeData = {
-  'Abu Dhabi': '00000',
-  Dubai: '00000',
-  Sharjah: '00000',
-  Ajman: '00000',
-  'Umm Al Quwain': '00000',
-  'Ras Al Khaimah': '00000',
-  Fujairah: '00000',
-}
+import { POSTAL_CODE } from '../constants'
 
 export default {
-  country: 'ARE',
-  abbr: 'AE',
-  postalCodeFrom: ONE_LEVEL,
-  postalCodeLevels: ['reference'],
-  firstLevelPostalCodes: firstLevelPostalCodes(emiratesPostalCodeData),
+  country: 'SAU',
+  abbr: 'SA',
+  postalCodeFrom: POSTAL_CODE,
   fields: [
     {
       hidden: true,
@@ -27,10 +13,12 @@ export default {
       size: 'medium',
     },
     {
-      hidden: true,
       name: 'postalCode',
-      maxLength: 50,
+      maxLength: 5,
       label: 'postalCode',
+      required: true,
+      mask: '99999',
+      regex: '^\\d{5}$',
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,
@@ -56,12 +44,11 @@ export default {
       size: 'xlarge',
     },
     {
+      hidden: true,
       name: 'reference',
       maxLength: 750,
-      label: 'emirates',
+      label: 'reference',
       size: 'xlarge',
-      level: 1,
-      options: getOneLevel(emiratesPostalCodeData),
     },
     {
       hidden: true,


### PR DESCRIPTION
Related to PRs:
https://github.com/vtex/address-form/pull/592
https://github.com/vtex/address-form/pull/590

The rule for Saudi Arabia (SAU) was added equal to the one in version 3.x and the rule for Arab Emirates was fixed. 

Before

https://github.com/vtex/address-form/assets/67066494/de3a67b8-121d-45bf-8b73-27153c3e1882


After

https://github.com/vtex/address-form/assets/67066494/855ba9eb-de7f-4aeb-b46e-76c9bb939d9a


Beta version:` vtex.address-form@4.24.4-beta.0 `