### PR TITLE
Feature/country field disabling when editing Address Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable editing country for existing address to be compliant with Profile V2 structure.
+
 ## [4.24.3] - 2024-06-06
 
 ### Fixed

--- a/react/CountrySelector.js
+++ b/react/CountrySelector.js
@@ -50,6 +50,10 @@ class CountrySelector extends Component {
       value: address.country.value,
     }
 
+    if (!!address?.addressId?.value) {
+      address.country.disabled = true
+    }
+
     return (
       <InputFieldContainer
         intl={intl}


### PR DESCRIPTION
#### What is the purpose of this pull request?

For profile V2 addresses schema we can´t change the country of an existing address because the schema is different per country so we are disabling this option when editing an address to be compliant with this structure.

#### How should this be manually tested?
Account to test: dunnesstoresqa
Workspace: devalex

https://devalex--dunnesstoresqa.myvtex.com/account

Open Address Edit form in My Account Addresses

#### Screenshots or example usage

Before:

Uploading Screen Recording 2024-07-04 at 12.30.43.mov…

After: 

https://github.com/vtex/address-form/assets/67066494/d6626c5a-5bb9-4b02-ae8b-dd526cb2c213


<img width="768" alt="Снимок экрана 2024-07-04 в 12 16 32" src="https://github.com/vtex/address-form/assets/98008460/0c7fad3f-78c0-47a6-a711-3dfe930f6a6e">

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
