### PR TITLE
Add autoUpperCase rule to fix postalCode validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- implemented autoUpperCase rule for countries with alphanumeric postal codes, ensuring consistent uppercase formatting.
+
 ## [4.24.5] - 2024-07-05
 
 ### Fixed

--- a/react/country/GBR.js
+++ b/react/country/GBR.js
@@ -22,6 +22,7 @@ export default {
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',

--- a/react/country/GIB.js
+++ b/react/country/GIB.js
@@ -1,10 +1,9 @@
 import { POSTAL_CODE } from '../constants'
 
 export default {
-  country: 'IRL',
-  abbr: 'IE',
+  country: null,
+  abbr: null,
   postalCodeFrom: POSTAL_CODE,
-  postalCodeProtectedFields: ['state'],
   fields: [
     {
       hidden: true,
@@ -15,35 +14,32 @@ export default {
     },
     {
       name: 'postalCode',
-      maxLength: 8,
+      maxLength: 50,
       label: 'postalCode',
-      required: true,
-      mask: '999 9999',
-      regex: /(?:^[AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?[0-9AC-FHKNPRTV-Y]{4}$/,
-      postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',
+      postalCodeAPI: false,
       autoUpperCase: true,
     },
     {
       name: 'street',
-      label: 'street',
+      label: 'addressLine1',
       required: true,
       size: 'xlarge',
     },
     {
+      hidden: true,
       name: 'number',
       maxLength: 750,
       label: 'number',
-      required: false,
-      size: 'mini',
+      size: 'small',
       autoComplete: 'nope',
     },
     {
       name: 'complement',
       maxLength: 750,
-      label: 'floorAndLetter',
-      size: 'large',
+      label: 'addressLine2',
+      size: 'xlarge',
     },
     {
       hidden: true,
@@ -69,8 +65,8 @@ export default {
     {
       name: 'state',
       maxLength: 100,
-      label: 'county',
-      required: false,
+      label: 'state',
+      required: true,
       size: 'large',
     },
     {
@@ -92,7 +88,7 @@ export default {
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
 
@@ -100,7 +96,14 @@ export default {
 
     neighborhood: {
       valueIn: 'long_name',
-      types: ['neighborhood'],
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
     },
 
     state: {
@@ -119,14 +122,35 @@ export default {
   },
   summary: [
     [
-      { name: 'street' },
-      { delimiter: ' ', name: 'number' },
-      { delimiter: ' ', name: 'complement' },
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
     ],
     [
-      { name: 'postalCode' },
-      { delimiter: ' ', name: 'city' },
-      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
     ],
   ],
 }

--- a/react/country/LTU.js
+++ b/react/country/LTU.js
@@ -1,10 +1,9 @@
 import { POSTAL_CODE } from '../constants'
 
 export default {
-  country: 'IRL',
-  abbr: 'IE',
+  country: null,
+  abbr: null,
   postalCodeFrom: POSTAL_CODE,
-  postalCodeProtectedFields: ['state'],
   fields: [
     {
       hidden: true,
@@ -15,35 +14,32 @@ export default {
     },
     {
       name: 'postalCode',
-      maxLength: 8,
+      maxLength: 50,
       label: 'postalCode',
-      required: true,
-      mask: '999 9999',
-      regex: /(?:^[AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?[0-9AC-FHKNPRTV-Y]{4}$/,
-      postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',
+      postalCodeAPI: false,
       autoUpperCase: true,
     },
     {
       name: 'street',
-      label: 'street',
+      label: 'addressLine1',
       required: true,
       size: 'xlarge',
     },
     {
+      hidden: true,
       name: 'number',
       maxLength: 750,
       label: 'number',
-      required: false,
-      size: 'mini',
+      size: 'small',
       autoComplete: 'nope',
     },
     {
       name: 'complement',
       maxLength: 750,
-      label: 'floorAndLetter',
-      size: 'large',
+      label: 'addressLine2',
+      size: 'xlarge',
     },
     {
       hidden: true,
@@ -69,8 +65,8 @@ export default {
     {
       name: 'state',
       maxLength: 100,
-      label: 'county',
-      required: false,
+      label: 'state',
+      required: true,
       size: 'large',
     },
     {
@@ -92,7 +88,7 @@ export default {
     number: {
       valueIn: 'long_name',
       types: ['street_number'],
-      required: true,
+      required: false,
       notApplicable: true,
     },
 
@@ -100,7 +96,14 @@ export default {
 
     neighborhood: {
       valueIn: 'long_name',
-      types: ['neighborhood'],
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
     },
 
     state: {
@@ -119,14 +122,35 @@ export default {
   },
   summary: [
     [
-      { name: 'street' },
-      { delimiter: ' ', name: 'number' },
-      { delimiter: ' ', name: 'complement' },
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
     ],
     [
-      { name: 'postalCode' },
-      { delimiter: ' ', name: 'city' },
-      { delimiter: ' (', name: 'state', delimiterAfter: ')' },
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
     ],
   ],
 }

--- a/react/country/MLT.js
+++ b/react/country/MLT.js
@@ -22,6 +22,7 @@ export default {
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',
@@ -139,8 +140,8 @@ export default {
         'Żebbuġ (Zebbug)',
         'Zebbug (Zebbug-Gozo)',
         'Zejtun (Zejtun)',
-        'Zurrieq (Zurrieq)'
-        ],
+        'Zurrieq (Zurrieq)',
+      ],
     },
     {
       name: 'receiverName',

--- a/react/country/NLD.js
+++ b/react/country/NLD.js
@@ -22,6 +22,7 @@ export default {
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -27,8 +27,15 @@ class StyleguideInput extends Component {
   }
 
   handleChange = (e) => {
+    const { field } = this.props
+    let { value } = e.target
+
+    if (field.autoUpperCase === true) {
+      value = value.toUpperCase()
+    }
+
     this.setState({ showErrorMessage: false })
-    this.props.onChange && this.props.onChange(e.target.value)
+    this.props.onChange && this.props.onChange(value)
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Today for alphanumeric postalCodes when typing the postalCode in lowerCase the UI invalidates the postalCode example for Ireland:

https://github.com/user-attachments/assets/52c27631-b042-41fd-90b7-a7a3a126ac0b

#### What problem is this solving?

After this change the rule autoUpperCase can be used to force the upper case on a specific field depending on the country by default when not set it will not affect the currently behavior.

#### How should this be manually tested?

Link the app and you can use the my account of dunnes:
https://capstest--dunnesstorespreprod.myvtex.com/account#/addresses/new

#### Screenshots or example usage

Behavior varying by country rule:

https://github.com/user-attachments/assets/6037753f-57f0-4737-b4d4-c0a0f60c0c45


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
