### PR TITLE
add autoUpperCase rule for alphanumerical postalCode countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- implemented autoUpperCase rule for countries with alphanumeric postal codes, ensuring consistent uppercase formatting.
+
 ## [3.36.6] - 2024-07-23
 
 ### Fixed

--- a/react/AddressContainer.js
+++ b/react/AddressContainer.js
@@ -75,6 +75,11 @@ class AddressContainer extends Component {
         rules.fields &&
         rules.fields.find((field) => field.name === 'postalCode')
 
+      // Convert postal code to uppercase if autoUpperCase is true
+      if (postalCodeField && postalCodeField.autoUpperCase) {
+        changedAddressFields.postalCode.value = changedAddressFields.postalCode.value.toUpperCase()
+      }
+
       const diffFromPrev =
         address.postalCode.value !== validatedAddress.postalCode.value
 

--- a/react/country/CAN.ts
+++ b/react/country/CAN.ts
@@ -26,6 +26,7 @@ const rules: PostalCodeRules = {
         'https://www.canadapost.ca/cpo/mc/personal/postalcode/fpc.jsf',
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',

--- a/react/country/GIB.ts
+++ b/react/country/GIB.ts
@@ -2,8 +2,8 @@ import { POSTAL_CODE } from '../constants'
 import type { PostalCodeRules } from '../types/rules'
 
 const rules: PostalCodeRules = {
-  country: 'GBR',
-  abbr: 'GB',
+  country: null,
+  abbr: null,
   postalCodeFrom: POSTAL_CODE,
   fields: [
     {
@@ -16,13 +16,10 @@ const rules: PostalCodeRules = {
     {
       name: 'postalCode',
       maxLength: 50,
-      fixedLabel: 'Postcode',
-      required: true,
-      mask: '',
-      regex: /^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/,
-      postalCodeAPI: false,
+      label: 'postalCode',
       size: 'small',
       autoComplete: 'nope',
+      postalCodeAPI: false,
       autoUpperCase: true,
     },
     {
@@ -30,6 +27,14 @@ const rules: PostalCodeRules = {
       label: 'addressLine1',
       required: true,
       size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
     },
     {
       name: 'complement',
@@ -54,24 +59,16 @@ const rules: PostalCodeRules = {
     {
       name: 'city',
       maxLength: 100,
-      label: 'town',
+      label: 'city',
       required: true,
       size: 'large',
     },
     {
       name: 'state',
       maxLength: 100,
-      label: 'county',
+      label: 'state',
       required: true,
       size: 'large',
-    },
-    {
-      name: 'number',
-      maxLength: 750,
-      label: 'number',
-      hidden: true,
-      defaultValue: 'N/A',
-      autoComplete: 'nope',
     },
     {
       name: 'receiverName',
@@ -89,24 +86,19 @@ const rules: PostalCodeRules = {
       required: false,
     },
 
-    street: {
+    number: {
       valueIn: 'long_name',
-      types: ['route', 'street_address'],
-      handler: (address, googleAddress) => {
-        address.street = { value: (googleAddress as { name: string }).name }
-
-        return address
-      },
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
     },
+
+    street: { valueIn: 'long_name', types: ['route'] },
 
     neighborhood: {
       valueIn: 'long_name',
       types: [
         'neighborhood',
-        'administrative_area_level_3',
-        'administrative_area_level_4',
-        'administrative_area_level_5',
-        'sublocality',
         'sublocality_level_1',
         'sublocality_level_2',
         'sublocality_level_3',
@@ -115,26 +107,14 @@ const rules: PostalCodeRules = {
       ],
     },
 
-    complement: {
-      valueIn: 'complement',
-      types: [
-        'street_number',
-        'colloquial_area',
-        'floor',
-        'room',
-        'premise',
-        'subpremise',
-      ],
-    },
-
     state: {
       valueIn: 'long_name',
-      types: ['postal_town', 'administrative_area_level_1'],
+      types: ['administrative_area_level_1'],
     },
 
     city: {
       valueIn: 'long_name',
-      types: ['locality', 'administrative_area_level_2'],
+      types: ['administrative_area_level_2', 'locality'],
     },
 
     receiverName: {
@@ -142,11 +122,36 @@ const rules: PostalCodeRules = {
     },
   },
   summary: [
-    [{ name: 'street' }, { delimiter: ', ', name: 'complement' }],
     [
-      { name: 'city' },
-      { delimiter: ', ', name: 'state' },
-      { delimiter: ' ', name: 'postalCode' },
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
+    ],
+    [
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
     ],
   ],
 }

--- a/react/country/IRL.ts
+++ b/react/country/IRL.ts
@@ -24,6 +24,7 @@ const rules: PostalCodeRules = {
       postalCodeAPI: true,
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',

--- a/react/country/LTU.ts
+++ b/react/country/LTU.ts
@@ -2,8 +2,8 @@ import { POSTAL_CODE } from '../constants'
 import type { PostalCodeRules } from '../types/rules'
 
 const rules: PostalCodeRules = {
-  country: 'GBR',
-  abbr: 'GB',
+  country: null,
+  abbr: null,
   postalCodeFrom: POSTAL_CODE,
   fields: [
     {
@@ -16,13 +16,10 @@ const rules: PostalCodeRules = {
     {
       name: 'postalCode',
       maxLength: 50,
-      fixedLabel: 'Postcode',
-      required: true,
-      mask: '',
-      regex: /^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/,
-      postalCodeAPI: false,
+      label: 'postalCode',
       size: 'small',
       autoComplete: 'nope',
+      postalCodeAPI: false,
       autoUpperCase: true,
     },
     {
@@ -30,6 +27,14 @@ const rules: PostalCodeRules = {
       label: 'addressLine1',
       required: true,
       size: 'xlarge',
+    },
+    {
+      hidden: true,
+      name: 'number',
+      maxLength: 750,
+      label: 'number',
+      size: 'small',
+      autoComplete: 'nope',
     },
     {
       name: 'complement',
@@ -54,24 +59,16 @@ const rules: PostalCodeRules = {
     {
       name: 'city',
       maxLength: 100,
-      label: 'town',
+      label: 'city',
       required: true,
       size: 'large',
     },
     {
       name: 'state',
       maxLength: 100,
-      label: 'county',
+      label: 'state',
       required: true,
       size: 'large',
-    },
-    {
-      name: 'number',
-      maxLength: 750,
-      label: 'number',
-      hidden: true,
-      defaultValue: 'N/A',
-      autoComplete: 'nope',
     },
     {
       name: 'receiverName',
@@ -89,24 +86,19 @@ const rules: PostalCodeRules = {
       required: false,
     },
 
-    street: {
+    number: {
       valueIn: 'long_name',
-      types: ['route', 'street_address'],
-      handler: (address, googleAddress) => {
-        address.street = { value: (googleAddress as { name: string }).name }
-
-        return address
-      },
+      types: ['street_number'],
+      required: false,
+      notApplicable: true,
     },
+
+    street: { valueIn: 'long_name', types: ['route'] },
 
     neighborhood: {
       valueIn: 'long_name',
       types: [
         'neighborhood',
-        'administrative_area_level_3',
-        'administrative_area_level_4',
-        'administrative_area_level_5',
-        'sublocality',
         'sublocality_level_1',
         'sublocality_level_2',
         'sublocality_level_3',
@@ -115,26 +107,14 @@ const rules: PostalCodeRules = {
       ],
     },
 
-    complement: {
-      valueIn: 'complement',
-      types: [
-        'street_number',
-        'colloquial_area',
-        'floor',
-        'room',
-        'premise',
-        'subpremise',
-      ],
-    },
-
     state: {
       valueIn: 'long_name',
-      types: ['postal_town', 'administrative_area_level_1'],
+      types: ['administrative_area_level_1'],
     },
 
     city: {
       valueIn: 'long_name',
-      types: ['locality', 'administrative_area_level_2'],
+      types: ['administrative_area_level_2', 'locality'],
     },
 
     receiverName: {
@@ -142,11 +122,36 @@ const rules: PostalCodeRules = {
     },
   },
   summary: [
-    [{ name: 'street' }, { delimiter: ', ', name: 'complement' }],
     [
-      { name: 'city' },
-      { delimiter: ', ', name: 'state' },
-      { delimiter: ' ', name: 'postalCode' },
+      {
+        name: 'street',
+      },
+      {
+        delimiter: ' ',
+        name: 'number',
+      },
+      {
+        delimiter: ', ',
+        name: 'complement',
+      },
+    ],
+    [
+      {
+        name: 'neighborhood',
+        delimiterAfter: ' - ',
+      },
+      {
+        name: 'city',
+      },
+      {
+        delimiter: ' - ',
+        name: 'state',
+      },
+    ],
+    [
+      {
+        name: 'postalCode',
+      },
     ],
   ],
 }

--- a/react/country/MLT.ts
+++ b/react/country/MLT.ts
@@ -23,6 +23,7 @@ const rules: PostalCodeRules = {
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',
@@ -140,8 +141,8 @@ const rules: PostalCodeRules = {
         'Żebbuġ (Zebbug)',
         'Zebbug (Zebbug-Gozo)',
         'Zejtun (Zejtun)',
-        'Zurrieq (Zurrieq)'
-        ],
+        'Zurrieq (Zurrieq)',
+      ],
     },
     {
       name: 'receiverName',
@@ -171,7 +172,8 @@ const rules: PostalCodeRules = {
       types: ['route'],
       handler: (address, googleAddress) => {
         address.street = { value: (googleAddress as { name: string }).name }
-          return address
+
+        return address
       },
     },
 

--- a/react/country/NLD.ts
+++ b/react/country/NLD.ts
@@ -23,6 +23,7 @@ const rules: PostalCodeRules = {
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',
+      autoUpperCase: true,
     },
     {
       name: 'street',

--- a/react/types/rules.ts
+++ b/react/types/rules.ts
@@ -43,6 +43,7 @@ export type PostalCodeFieldRule = RuleLabel & {
   maxLength?: number
   postalCodeAPI?: boolean
   autoComplete?: boolean | string
+  autoUpperCase?: boolean
   notApplicable?: boolean
   hidden?: boolean
   basedOn?: Fields

--- a/react/validateAddress.ts
+++ b/react/validateAddress.ts
@@ -95,6 +95,20 @@ export function validateChangedFields(changedFields, address, rules) {
   return reduce(
     changeFieldsNames,
     (resultAddress, fieldName) => {
+      const fieldRule =
+        rules.fields && rules.fields.find((field) => field.name === fieldName)
+
+      // Convert value to uppercase if autoUpperCase is true
+      if (
+        fieldRule &&
+        fieldRule.autoUpperCase &&
+        typeof resultAddress[fieldName].value === 'string'
+      ) {
+        resultAddress[fieldName].value = resultAddress[
+          fieldName
+        ].value.toUpperCase()
+      }
+
       const validationResult = validateField(
         resultAddress[fieldName].value,
         fieldName as Fields,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Today for alphanumeric postalCodes when typing the postalCode in lowerCase the UI invalidates the postalCode example for Ireland:

https://github.com/user-attachments/assets/52c27631-b042-41fd-90b7-a7a3a126ac0b

#### What problem is this solving?

After this change the rule autoUpperCase can be used to force the upper case on a specific field depending on the country by default when not set it will not affect the currently behavior.

#### How should this be manually tested?

Link the app and you can use the my account of dunnes:
https://addprod--dunnesstoresqa.myvtex.com/checkout/cart/add/?sku=24976&qty=1&seller=1&sc=4&sku=24368&qty=1&seller=1&sc=4&sku=23472&qty=1&seller=1&sc=4

#### Screenshots or example usage

Behavior varying by country rule:


https://github.com/user-attachments/assets/94a83017-c3ed-4386-a0f7-a1f82239ad63


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
