### PR TITLE
Fix malta geolocation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Malta geolocation rules.
+
 ## [3.36.5] - 2024-07-02
 
 ### Fixed

--- a/react/country/MLT.ts
+++ b/react/country/MLT.ts
@@ -156,7 +156,7 @@ const rules: PostalCodeRules = {
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],
-      required: false,
+      required: true,
     },
 
     number: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix value of geolocation to `true`. It relates to the task [LOC-15609](https://vtex-dev.atlassian.net/browse/LOC-15609) and [this Slack thread](https://vtex.slack.com/archives/CT0S37223/p1714054186591079).
**IMPORTANT:** Please prioritize this PR because it is related to a go-live from the account `carpisa`.

#### How should this be manually tested?
[Test store](https://geolocationtestmain--carpisa.myvtex.com/checkout/cart/add/?sku=18517&qty=2&seller=1&sc=4)

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-15609]: https://vtex-dev.atlassian.net/browse/LOC-15609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ