### PR TITLE
Avoid optional field at my account for Postal Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- required prop for postalCode at DNK, FIN, GIB, LTU and SWE country rules.
-- required prop for emirates at ARE country rule.
-- placeholder prop empty for default country rule.
+- Required prop for postalCode at DNK, FIN, GIB, LTU and SWE country rules.
+- Required prop for emirates at ARE country rule.
+- Placeholder prop empty for default country rule.
 
 ## [4.24.6] - 2024-07-15
 
 ### Added
-- implemented autoUpperCase rule for countries with alphanumeric postal codes, ensuring consistent uppercase formatting.
+- Implemented autoUpperCase rule for countries with alphanumeric postal codes, ensuring consistent uppercase formatting.
 
 ## [4.24.5] - 2024-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- required prop for postalCode at the default, DNK, FIN, GIB, LTU and SWE country rules.
+- required prop for postalCode at DNK, FIN, GIB, LTU and SWE country rules.
 - required prop for emirates at ARE country rule.
+- placeholder prop empty for default country rule.
 
 ## [4.24.6] - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- required prop for postalCode at the default, DNK, FIN, GIB, LTU and SWE country rules.
+- required prop for emirates at ARE country rule.
+
 ## [4.24.6] - 2024-07-15
 
 ### Added

--- a/react/country/ARE.js
+++ b/react/country/ARE.js
@@ -59,6 +59,7 @@ export default {
       name: 'reference',
       maxLength: 750,
       label: 'emirates',
+      required: true,
       size: 'xlarge',
       level: 1,
       options: getOneLevel(emiratesPostalCodeData),

--- a/react/country/DNK.js
+++ b/react/country/DNK.js
@@ -16,6 +16,7 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
+      required: true,
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,

--- a/react/country/FIN.js
+++ b/react/country/FIN.js
@@ -16,6 +16,7 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
+      required: true,
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,

--- a/react/country/GIB.js
+++ b/react/country/GIB.js
@@ -16,6 +16,7 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
+      required: true,
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,

--- a/react/country/LTU.js
+++ b/react/country/LTU.js
@@ -16,6 +16,7 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
+      required: true,
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,

--- a/react/country/SWE.js
+++ b/react/country/SWE.js
@@ -16,6 +16,7 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
+      required: true,
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -16,9 +16,9 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
-      required: true,
       size: 'small',
       autoComplete: 'nope',
+      placeholder: '',
       postalCodeAPI: false,
     },
     {

--- a/react/country/default.js
+++ b/react/country/default.js
@@ -16,6 +16,7 @@ export default {
       name: 'postalCode',
       maxLength: 50,
       label: 'postalCode',
+      required: true,
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,


### PR DESCRIPTION
#### What is the purpose of this pull request?

When adding a new address inside my account the user is presented today with a field that is mandatory but the interface point it as optional. Example:

<img width="676" alt="image" src="https://github.com/user-attachments/assets/950a78ee-13b4-4052-8bdc-3cf3fdb69c63">

<img width="676" alt="image" src="https://github.com/user-attachments/assets/e677d090-3e5d-4486-a711-c330c243ebc2">

After Change:
<img width="676" alt="image" src="https://github.com/user-attachments/assets/6187efdb-a7ef-48fd-9472-a557e8771ea8">

<img width="676" alt="image" src="https://github.com/user-attachments/assets/70511e5d-50a1-41d1-9dc4-05962aa30701">


#### What problem is this solving?

This makes the interface more precise and therefore more user-friendly for users.

#### How should this be manually tested?

Test it here: https://optionaladdress--dunnesstorespreprod.myvtex.com/

Its important not to test in master because in master you have a css currently at the theme to hide the optional text. This was removed at this beta so we can avoid this and have the right native behavior already at the address form:
`dunnesstoresqa.dunnes-storefront@35.0.13-beta.0`

This version is already installed at the workspace provided.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
