### PR TITLE
Add additional classNames to the styleguide inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- "disabled" and "invalid" classNames for the StyleguideInput component.
+- "...-disabled", "...-empty", "...-focused" and "...-invalid" classNames for the StyleguideInput component.
 
 ## [4.24.7] - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- "disabled" and "invalid" classNames for the StyleguideInput component.
+
 ## [4.24.7] - 2024-08-30
 
 ### Added

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -23,6 +23,7 @@ class StyleguideInput extends Component {
     this.state = {
       isInputValid: props.address[props.field.name].valid || true,
       showErrorMessage: false,
+      isFocused: false,
     }
   }
 
@@ -50,7 +51,7 @@ class StyleguideInput extends Component {
   }
 
   handleFocus = () => {
-    this.setState({ showErrorMessage: false })
+    this.setState({ showErrorMessage: false, isFocused: true })
   }
 
   handleSubmit = (event) => {
@@ -60,7 +61,7 @@ class StyleguideInput extends Component {
   }
 
   handleBlur = (event) => {
-    this.setState({ showErrorMessage: true })
+    this.setState({ showErrorMessage: true, isFocused: false })
     this.props.onBlur && this.props.onBlur(event)
   }
 
@@ -143,6 +144,10 @@ class StyleguideInput extends Component {
       disabled ? 'vtex-address-form__field-disabled' : ''
     } ${
       !valid ? 'vtex-address-form__field-invalid' : ''
+    } ${
+      !address[field.name].value ? 'vtex-address-form__field-empty' : ''
+    } ${
+      this.state.isFocused ? 'vtex-address-form__field-focused' : ''
     }`
 
     if (field.name === 'postalCode') {

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -82,6 +82,8 @@ class StyleguideInput extends Component {
 
     const disabled = !!address[field.name].disabled
 
+    const valid = address[field.name].valid === false ? false : true
+
     const loading =
       loadingProp != null ? loadingProp : address[field.name].loading
 
@@ -137,6 +139,10 @@ class StyleguideInput extends Component {
       field.name
     } vtex-address-form__field--${field.size || 'xlarge'} ${
       field.hidden ? 'dn' : ''
+    } ${
+      disabled ? 'vtex-address-form__field-disabled' : ''
+    } ${
+      !valid ? 'vtex-address-form__field-invalid' : ''
     }`
 
     if (field.name === 'postalCode') {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Workspace to test https://prod--dunnesstorespreprod.myvtex.com/

Add additional classNames to the styleguide inputs. It will bring a possibility to customize the label color or position.

#### What problem is this solving?

In the design concept of our client the field label should have a red color when the field fails validation and since the label tag is on the upper level then input tag that has validation text, it's impossible to style it via CSS.

#### How should this be manually tested?

Just to check that these additional classNames are presented in the address form field HTML

#### Screenshots or example usage
<img width="414" alt="Снимок экрана 2024-09-12 в 10 52 03" src="https://github.com/user-attachments/assets/e38482d3-16dc-4c77-9395-c98303f7655e">
<img width="1072" alt="Снимок экрана 2024-09-12 в 10 52 48" src="https://github.com/user-attachments/assets/ae2d3e7a-f741-482c-a82a-8e0b9e4123ec">

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
