### PR TITLE
Changed the rules for France (FRA) so the number field is shown to users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed the rules for France (FRA) so the number field is shown to users.
+
 ## [3.37.0] - 2024-07-29
 
 ### Added

--- a/react/country/FRA.ts
+++ b/react/country/FRA.ts
@@ -31,7 +31,7 @@ const rules: PostalCodeRules = {
       size: 'xlarge',
     },
     {
-      hidden: true,
+      hidden: false,
       name: 'number',
       maxLength: 750,
       label: 'number',


### PR DESCRIPTION
Tracked in [LOC-16220](https://vtex-dev.atlassian.net/browse/LOC-16220).

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-16220]: https://vtex-dev.atlassian.net/browse/LOC-16220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ