### PR TITLE
Fix: Mask field as NaN for Alphanumerical Postal Codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Input field for Postal Code at CAN, GBR, IRL and NLD for mobile.
+
 ## [4.24.7] - 2024-08-30
 
 ### Added

--- a/react/country/CAN.js
+++ b/react/country/CAN.js
@@ -18,7 +18,7 @@ export default {
       maxLength: 50,
       label: 'postalCode',
       required: true,
-      mask: 'A9A 9A9',
+      mask: NaN,
       regex: '^[A-z][0-9][A-z]\\ ?[0-9][A-z][0-9]$',
       postalCodeAPI: true,
       forgottenURL:

--- a/react/country/GBR.js
+++ b/react/country/GBR.js
@@ -17,8 +17,9 @@ export default {
       maxLength: 50,
       fixedLabel: 'Postcode',
       required: true,
-      mask: '',
-      regex: /^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/,
+      mask: NaN,
+      regex:
+        /^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/,
       postalCodeAPI: false,
       size: 'small',
       autoComplete: 'nope',

--- a/react/country/IRL.js
+++ b/react/country/IRL.js
@@ -18,7 +18,7 @@ export default {
       maxLength: 8,
       label: 'postalCode',
       required: true,
-      mask: '999 9999',
+      mask: NaN,
       regex: /(?:^[AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?[0-9AC-FHKNPRTV-Y]{4}$/,
       postalCodeAPI: true,
       size: 'small',

--- a/react/country/NLD.js
+++ b/react/country/NLD.js
@@ -17,7 +17,7 @@ export default {
       label: 'postalCode',
       maxLength: 7,
       required: true,
-      mask: '9999 AA',
+      mask: NaN,
       regex: /^[1-9][0-9]{3} ?(?!sa|sd|ss)[a-zA-Z]{2}$/,
       postalCodeAPI: false,
       size: 'small',


### PR DESCRIPTION
Related to report:
https://vtexhelp.zendesk.com/agent/tickets/1098502

The logic shouldShowNumberKeyboard needs improvement so we are bypassing that fixing the mask for alphanumerical countries for NaN in order to fix the input type:

![image](https://github.com/user-attachments/assets/9e660bb9-d3c7-4679-87ba-810ea703ce0a)
