### PR TITLE
update rules + shouldShowNumberKeyboard logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Logic to validate if a country should use Number Keyboard (shouldShowNumberKeyboard).
+
 ## [4.24.7] - 2024-08-30
 
 ### Added

--- a/react/PostalCodeGetter.js
+++ b/react/PostalCodeGetter.js
@@ -89,9 +89,12 @@ class PostalCodeGetter extends Component {
       default:
       case POSTAL_CODE: {
         const field = getField('postalCode', rules)
-        const shouldShowNumberKeyboard = !Number.isNaN(
-          removeNonWords(field.mask)
-        )
+        const numericString = field.mask ? removeNonWords(field.mask) : ''
+        const isPurelyNumeric =
+          numericString === '' || /^\d+$/.test(numericString)
+        const shouldShowNumberKeyboard = isNaN(field.mask)
+          ? isPurelyNumeric
+          : false
 
         return (
           <InputFieldContainer

--- a/react/country/GBR.js
+++ b/react/country/GBR.js
@@ -17,7 +17,8 @@ export default {
       maxLength: 50,
       fixedLabel: 'Postcode',
       required: true,
-      mask: '',
+      // UK has different patterns for postal codes alphanumericals, so we need can't use a mask.
+      mask: NaN,
       regex: /^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/,
       postalCodeAPI: false,
       size: 'small',

--- a/react/country/IRL.js
+++ b/react/country/IRL.js
@@ -18,7 +18,7 @@ export default {
       maxLength: 8,
       label: 'postalCode',
       required: true,
-      mask: '999 9999',
+      mask: 'A99 A9A9',
       regex: /(?:^[AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?[0-9AC-FHKNPRTV-Y]{4}$/,
       postalCodeAPI: true,
       size: 'small',


### PR DESCRIPTION
Related to report:
https://vtexhelp.zendesk.com/agent/tickets/1098502

Rewrite the logic for shouldShowNumberKeyboard.
It was added a logic for NaN mask type to cover the use case of UK that can have different patterns like:
SW1A 1AA – Buckingham Palace, London
W1A 1AA – BBC Broadcasting House, London
EC1A 1BB – Central London
M1 1AE – Manchester
B1 1AA – Birmingham

So in order not to change the default behavior (not defining a mask should have the numeric keyboard)  we return the alphanumerical board for mask defined like NaN.

![image](https://github.com/user-attachments/assets/9e660bb9-d3c7-4679-87ba-810ea703ce0a)
