### PR TITLE
Fix: shouldShowNumberKeyboard logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Tests to validate if a country should use Number Keyboard (shouldShowNumberKeyboard).
+
+### Fixed
+- Logic to validate if a country should use Number Keyboard (shouldShowNumberKeyboard).
+
 ## [4.25.0] - 2024-09-13
 
 ### Fixed

--- a/react/PostalCodeGetter.js
+++ b/react/PostalCodeGetter.js
@@ -15,7 +15,7 @@ import {
   injectAddressContext,
   addressContextPropTypes,
 } from './addressContainerContext'
-import { removeNonWords } from './transforms/utils'
+import { shouldShowNumberKeyboard as determineShouldShowNumberKeyboard } from './transforms/shouldShowNumberKeyboard'
 
 class PostalCodeGetter extends Component {
   render() {
@@ -89,12 +89,8 @@ class PostalCodeGetter extends Component {
       default:
       case POSTAL_CODE: {
         const field = getField('postalCode', rules)
-        const numericString = field.mask ? removeNonWords(field.mask) : ''
-        const isPurelyNumeric =
-          numericString === '' || /^\d+$/.test(numericString)
-        const shouldShowNumberKeyboard = isNaN(field.mask)
-          ? isPurelyNumeric
-          : false
+        const mask = field?.mask
+        const shouldShowNumberKeyboard = determineShouldShowNumberKeyboard(mask)
 
         return (
           <InputFieldContainer

--- a/react/transforms/shouldShowNumberKeyboard.js
+++ b/react/transforms/shouldShowNumberKeyboard.js
@@ -1,0 +1,30 @@
+/**
+ * Removes non-numeric characters from a string, keeping only digits, spaces, and dashes.
+ * @param {string} string
+ * @returns {string}
+ */
+function removeNonWords(string) {
+  return (string || '').replace(/[^\d\s-]/g, '')
+}
+
+/**
+ * Determines whether to show the number keyboard based on the input mask.
+ * @param {string|number|null|undefined|NaN} [mask]
+ * @returns {boolean}
+ */
+export function shouldShowNumberKeyboard(mask) {
+  if (mask === undefined || mask === null || mask === '') {
+    return true
+  }
+
+  if (Number.isNaN(mask)) {
+    return false
+  }
+
+  const maskString = typeof mask === 'number' ? mask.toString() : mask
+
+  const numericString = removeNonWords(maskString)
+  const isPurelyNumeric = /^[\d\s-]+$/.test(numericString)
+
+  return isPurelyNumeric && !/[a-zA-Z]/.test(maskString)
+}

--- a/react/transforms/shouldShowNumberKeyboard.test.js
+++ b/react/transforms/shouldShowNumberKeyboard.test.js
@@ -1,0 +1,43 @@
+import { shouldShowNumberKeyboard } from './shouldShowNumberKeyboard'
+
+describe('shouldShowNumberKeyboard', () => {
+  test('Should return true for mask rule undefined', () => {
+    expect(shouldShowNumberKeyboard(undefined)).toBe(true)
+  })
+
+  test('Should return true for mask rule null', () => {
+    expect(shouldShowNumberKeyboard(null)).toBe(true)
+  })
+
+  test('Should return true for mask rule empty string', () => {
+    expect(shouldShowNumberKeyboard('')).toBe(true)
+  })
+
+  test('Should return true for mask rule numeric string without separators', () => {
+    expect(shouldShowNumberKeyboard('9999')).toBe(true)
+  })
+
+  test('Should return true for mask rule numeric string with spaces', () => {
+    expect(shouldShowNumberKeyboard('999 99')).toBe(true)
+  })
+
+  test('Should return true for mask rule numeric string with dashes', () => {
+    expect(shouldShowNumberKeyboard('9999-99')).toBe(true)
+  })
+
+  test('Should return false for mask rulee for string with letters', () => {
+    expect(shouldShowNumberKeyboard('999AA')).toBe(false)
+  })
+
+  test('Should return false for mask rulee for string with mixed letters and spaces', () => {
+    expect(shouldShowNumberKeyboard('999 AA')).toBe(false)
+  })
+
+  test('Should return false for mask rulee for mixed numeric and letter string with dashes', () => {
+    expect(shouldShowNumberKeyboard('9AA9-99')).toBe(false)
+  })
+
+  test('Should return false for mask rulee for NaN', () => {
+    expect(shouldShowNumberKeyboard(NaN)).toBe(false)
+  })
+})


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the behavior implemented here: https://github.com/vtex/address-form/pull/610

And add tests to guarantee that all the cases are covered so the function shouldShowNumberKeyboard:
    ✓ Should return true for mask rule undefined (1 ms)
    ✓ Should return true for mask rule null
    ✓ Should return true for mask rule empty string
    ✓ Should return true for mask rule numeric string without separators (1 ms)
    ✓ Should return true for mask rule numeric string with spaces
    ✓ Should return true for mask rule numeric string with dashes
    ✓ Should return false for mask rulee for string with letters
    ✓ Should return false for mask rulee for string with mixed letters and spaces
    ✓ Should return false for mask rulee for mixed numeric and letter string with dashes (1 ms)
    ✓ Should return false for mask rulee for NaN

#### What problem is this solving?

This validation is not correct implemented:
https://github.com/vtex/address-form/pull/610/files#diff-ba3efeb1ca67806eaaa1c0260a917dec21401eb72f01f9311243c42e73c57717R95

#### How should this be manually tested?

You can run yarn test and use this workspace for validation:
https://debug--dunnesstoresqa.myvtex.com/account#/addresses/new


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
