### PR TITLE
Add new postal codes to DOM.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Malta geolocation rules.
+
 ## [4.24.6] - 2024-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Two new postal codes to Dominican Republic (DOM) country file.
+
 ## [4.25.2] - 2024-09-18
 
 ### Added

--- a/react/country/DOM.js
+++ b/react/country/DOM.js
@@ -1,6 +1,6 @@
 import { TWO_LEVELS } from '../constants'
-import { secondLevelPostalCodes } from '../transforms/postalCodes'
 import { getOneLevel, getTwoLevels } from '../transforms/addressFieldsOptions'
+import { secondLevelPostalCodes } from '../transforms/postalCodes'
 
 // Based on sheet provided by Rodolfo Bússola:
 // https://docs.google.com/spreadsheets/d/1_uoFfVCg-E8lrGJ235ZkcqnK0cspyX53/edit?usp=sharing&ouid=113929948326320493678&rtpof=true&sd=true
@@ -43,7 +43,8 @@ const countryData = {
     'El Pino': '63400'
   },
   'Distrito Nacional': {
-    'Santo Domingo De Guzmán': '10101'
+    'Santo Domingo De Guzmán': '10101',
+    'Santo Domingo Distrito Nacional': '10100'
   },
   Duarte: {
     'San Francisco de Macorís': '31000',
@@ -69,7 +70,8 @@ const countryData = {
     Moca: '53011',
     'Cayetano Germosén': '56100',
     'Gaspar Hernández': '56200',
-    'Jamao Al Norte': '56400'
+    'Jamao Al Norte': '56400',
+    'El Higuerito': '56000'
   },
   'Hato Mayor': {
     'Hato Mayor': '25000',

--- a/react/country/MLT.js
+++ b/react/country/MLT.js
@@ -156,7 +156,7 @@ export default {
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],
-      required: true,
+      required: false,
     },
 
     number: {

--- a/react/country/MLT.js
+++ b/react/country/MLT.js
@@ -156,7 +156,7 @@ export default {
     postalCode: {
       valueIn: 'long_name',
       types: ['postal_code'],
-      required: false,
+      required: true,
     },
 
     number: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

It relates to the task [LOC-16501](https://vtex-dev.atlassian.net/browse/LOC-16501), adding two new postal codes to the file `DOM.js`.

#### How should this be manually tested?
[Test store here](https://dompostalcodes4x--b2cnespressodominicana.myvtex.com)
#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-16501]: https://vtex-dev.atlassian.net/browse/LOC-16501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ