### PR TITLE
Fix DNK postal code rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Denmark (DNK) postal code rules.
+
 ## [3.37.2] - 2024-10-02
 
 ### Added

--- a/react/country/DNK.ts
+++ b/react/country/DNK.ts
@@ -15,8 +15,10 @@ const rules: PostalCodeRules = {
     },
     {
       name: 'postalCode',
-      maxLength: 50,
-      label: 'postalCode',
+      maxLength: 4,
+      label: 'Postnumre',
+      mask: '1234',
+      regex: '^\\d{4}$',
       size: 'small',
       autoComplete: 'nope',
       postalCodeAPI: false,


### PR DESCRIPTION
#### What is the purpose of this pull request?

It relates to the task [LOC-16864](https://vtex-dev.atlassian.net/browse/LOC-16864). It fixes the behavior in the field `postalCode` for `DNK`.

#### How should this be manually tested?
Accepted values now should be only 4 digits-long strings.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-16864]: https://vtex-dev.atlassian.net/browse/LOC-16864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ