### PR TITLE
Fix russian rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Russia (RUS) number attribute hidden.
 
 ## [4.25.5] - 2024-10-09
 

--- a/react/country/RUS.js
+++ b/react/country/RUS.js
@@ -308,7 +308,6 @@ export default {
     },
     {
       name: 'number',
-      hidden: true,
       maxLength: 750,
       label: 'number',
       size: 'mini',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Changing the field number in the Russian rule because it was hidden, and it should not be.

#### What problem is this solving?

A client is using this rule and is getting an error because the field number (that does not appear) is empty.

#### How should this be manually tested?

Go to add new addresses and see if there's a field number for Russia.

#### Screenshots or example usage

#### Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
