### PR TITLE
 Changed Postal code for Santa Elena in Colombia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Postal code for Santa Elena in COL. This locality will now use an 8-digit code.
+
 ## [4.26.0] - 2024-10-31
 
 ### Fixed

--- a/react/country/COL.js
+++ b/react/country/COL.js
@@ -120,7 +120,7 @@ const countryData = {
     'San Roque': '05670',
     'San Vicente Ferrer': '05674',
     'Santa Bárbara': '05679',
-    'Santa Elena': '05001',
+    'Santa Elena': '05001004',
     'Santa Fé De Antioquia': '05042',
     'Santa Rosa De Osos': '05686',
     'Santo Domingo': '05690',
@@ -1220,7 +1220,7 @@ export default {
       name: 'postalCode',
       postalCodeAPI: false,
       required: true,
-      regex: /^([\d]{5})$/,
+      regex: /^([\d]{5})|05001004$/,
       size: 'small',
     },
     {


### PR DESCRIPTION
This single locality will now use an 8-digit code.
Tracked in [LOC-17102](https://vtex-dev.atlassian.net/browse/LOC-17102).

#### What problem is this solving?

A client mentioned they are having issues with the 5-digit code for this locality, as it is shared with other localities and products are being shipped to the wrong areas.

This might affects clients already registered in the area using the old ZIP code.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

[LOC-17102]: https://vtex-dev.atlassian.net/browse/LOC-17102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ