### PR TITLE
Fix guatemala locality name: Huitán

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Guatemala's locality name: Huitán.
+
 ## [4.26.4] - 2025-05-19
 
 ### Fixed

--- a/react/country/GTM.js
+++ b/react/country/GTM.js
@@ -348,7 +348,7 @@ const countryData = {
     'El Tambor (El Palmar)': '9032',
     'Flores Costa Cuca': '9022',
     Genova: '9021',
-    Huitla: '9015',
+    Huitán: '9015',
     'La Esperanza': '9023',
     'Las Mercedes (Colomba)': '9033',
     'Las Palmas Coatepeque': '9027',


### PR DESCRIPTION
#### What is the purpose of this pull request?

**:warning: Please review and approve but do not merge yet.**
It relates to the task [LOC-19993](https://vtex-dev.atlassian.net/browse/LOC-19993). It fixes a misspelling in the name of the locality `Huitán` in Guatemala.

This change was discussed and approved on [this Slack thread](https://vtex.slack.com/archives/C1FRE8V9A/p1745602073786109).

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-19993]: https://vtex-dev.atlassian.net/browse/LOC-19993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ