### PR TITLE
chore: add test execution to CI pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -6,6 +6,9 @@
     pipelines:
       - name: node-ci-v2
         parameters:
+          nodeCommands:
+            - install
+            - test:coverage
           sonarProjectName: address-form
           nodeVersion: 20-bookworm
         runtime:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint:locales": "intl-equalizer",
-    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json}\""
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json}\"",
+    "test:coverage": "yarn --cwd react install --frozen-lockfile && yarn --cwd react test:coverage"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary
- Add `test:coverage` script to package.json
- Add `nodeCommands` with test step to `.vtex/deployment.yaml` so CI runs tests on PRs

## Context
Part of test-execution rollout for Checkout Experience repos. Goal: every repo runs its test suite on every PR via DK CI.

## Test plan
- [ ] Verify pipeline runs on this PR at http://dkcicd.vtex.systems/
- [ ] Verify test step executes (or stub passes if no tests)
- [ ] Confirm no regressions in existing pipeline steps

> **Note:** Any pre-existing CI failures on this repo are unrelated to this change.
