### PR TITLE
Fix Paraguay's location typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Virgin Islands' postal code validation
+- Paraguay's locality Itauguá typo
 
 ## [3.42.0] - 2025-12-09
 

--- a/react/country/PRY.ts
+++ b/react/country/PRY.ts
@@ -128,7 +128,7 @@ const countryData = {
     'Fernando De La Mora': '2300',
     Guarambare: '2670',
     Ita: '2710',
-    Itagua: '2740',
+    Itauguá: '2740',
     'Julian Augusto Saldivar': '2630',
     Lambare: '2420',
     Limpio: '2020',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix Paraguay's location typo from `Itagua` to `Itauguá`.

#### What problem is this solving?

Requested on the task [LOC-25666](https://vtex-dev.atlassian.net/browse/LOC-25666). It was reported that this typo was preventing sales to this locality.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-25666]: https://vtex-dev.atlassian.net/browse/LOC-25666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ