### PR TITLE
Fix Paraguay's location typo (profile form)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Virgin Islands' postal code validation
-- Paraguay's locality Itauguá typo
+- Fix misspelled city name in PRY country data: Itagua → Itauguá
 
 ## [4.28.0] - 2025-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Virgin Islands' postal code validation
+- Paraguay's locality Itauguá typo
 
 ## [4.28.0] - 2025-12-09
 

--- a/react/country/PRY.js
+++ b/react/country/PRY.js
@@ -127,7 +127,7 @@ const countryData = {
     'Fernando De La Mora': '2300',
     Guarambare: '2670',
     Ita: '2710',
-    Itagua: '2740',
+    Itauguá: '2740',
     'Julian Augusto Saldivar': '2630',
     Lambare: '2420',
     Limpio: '2020',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix Paraguay's location typo from `Itagua` to `Itauguá`.

**Important:** Regarding the impact of this change for previous uses os the changed value, the checkout team conducted tests that proved changes like this to be permited without unexpecteded side effects. It was informed on [this Slack thread](https://vtex.slack.com/archives/C07HU0VE9AB/p1777554615106379?thread_ts=1775139295.767929&cid=C07HU0VE9AB).

#### What problem is this solving?

Requested on the task [LOC-25666](https://vtex-dev.atlassian.net/browse/LOC-25666). It was reported that this typo was preventing sales to this locality.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-25666]: https://vtex-dev.atlassian.net/browse/LOC-25666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ