### PR TITLE
Fix Virgin Islands' postal code validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Deduplicated test fixtures: shared Google Geocoder payloads (factory exported from `postalCodeGoogleAddress.js`), address/geolocation mock bases, and `sharedMockRuleFields` for `useOneLevel` / `useThreeLevels` to satisfy Sonar CPD on new code.
 
+### Fixed
+
+- Paraguay's locality Itauguá typo
+
 ## [3.42.0] - 2025-12-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Paraguay's locality Itauguá typo
+- Virgin Islands' postal code validation
 
 ## [3.42.0] - 2025-12-09
 

--- a/react/country/PRY.ts
+++ b/react/country/PRY.ts
@@ -128,7 +128,7 @@ const countryData = {
     'Fernando De La Mora': '2300',
     Guarambare: '2670',
     Ita: '2710',
-    Itagua: '2740',
+    Itauguá: '2740',
     'Julian Augusto Saldivar': '2630',
     Lambare: '2420',
     Limpio: '2020',

--- a/react/country/PRY.ts
+++ b/react/country/PRY.ts
@@ -128,7 +128,7 @@ const countryData = {
     'Fernando De La Mora': '2300',
     Guarambare: '2670',
     Ita: '2710',
-    Itauguá: '2740',
+    Itagua: '2740',
     'Julian Augusto Saldivar': '2630',
     Lambare: '2420',
     Limpio: '2020',

--- a/react/country/VIR.ts
+++ b/react/country/VIR.ts
@@ -19,8 +19,8 @@ const rules: PostalCodeRules = {
       fixedLabel: 'ZIP',
       required: true,
       mask: '99999-9999',
-      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)-\d{0,4}$',
-      // Asserts zipcode starts with 008, then contains one of the local accepted area values, then followed by hyphen and 4 digits.
+      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)(-\d{4})?$',
+      // Asserts zipcode starts with 008, then contains one of the local accepted area values, optionally followed by hyphen and exactly 4 digits.
       postalCodeAPI: true,
       forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',
       size: 'small',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Relates to the task [LOC-26438](https://vtex-dev.atlassian.net/browse/LOC-26438)
Fix postal code validation for Virgin Islands (VIR). Previously it considered the hyphen as a required digit, when it should be optional.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-26438]: https://vtex-dev.atlassian.net/browse/LOC-26438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ