### PR TITLE
Fix Virgin Islands' postal code validation (profile form)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Virgin Islands' postal code validation
+
 ## [4.28.0] - 2025-12-09
 
 ### Added

--- a/react/country/VIR.js
+++ b/react/country/VIR.js
@@ -18,8 +18,8 @@ export default {
       fixedLabel: 'ZIP',
       required: true,
       mask: '99999-9999',
-      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)-\d{0,4}$',
-      // Asserts zipcode starts with 008, then contains one of the local accepted area values, then followed by hyphen and 4 digits.
+      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)(-\d{4})?$',
+      // Asserts zipcode starts with 008, then contains one of the local accepted area values, optionally followed by hyphen and exactly 4 digits.
       postalCodeAPI: true,
       forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',
       size: 'small',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Relates to the task [LOC-26438](https://vtex-dev.atlassian.net/browse/LOC-26438)
Fix postal code validation for Virgin Islands (VIR). Previously it considered the hyphen as a required digit, when it should be optional.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-26438]: https://vtex-dev.atlassian.net/browse/LOC-26438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ