### PR TITLE
Fix VIR postal code validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.44.2] - 2026-07-24
+
 ### Fixed
 
 - Fixed Virgin Islands (VIR) address form not advancing to payment (`react/country/VIR.ts` only): corrected unescaped `\d` in the postal code regex string (was matching a literal `d` instead of digits); changed mask from `99999-9999` to `99999` to match the 5-digit USPS ZIP format; made the hidden `state` field non-blocking by removing `required` and `optionsPairs` and keeping `defaultValue: 'VI'` — the postal code API returns an empty `state` for VIR and `defaultValue` is never applied automatically, so the hidden required field could never be filled and silently failed validation, blocking checkout (verified that the checkout API accepts VIR addresses with both `state: 'VI'` and `state: null`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Virgin Islands (VIR) address form not advancing to payment (`react/country/VIR.ts` only): corrected unescaped `\d` in the postal code regex string (was matching a literal `d` instead of digits); changed mask from `99999-9999` to `99999` to match the 5-digit USPS ZIP format; made the hidden `state` field non-blocking by removing `required` and `optionsPairs` and keeping `defaultValue: 'VI'` — the postal code API returns an empty `state` for VIR and `defaultValue` is never applied automatically, so the hidden required field could never be filled and silently failed validation, blocking checkout (verified that the checkout API accepts VIR addresses with both `state: 'VI'` and `state: null`).
+
 ## [3.44.1] - 2026-07-23
 
 ## [3.44.0] - 2026-07-20

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "address-form",
   "vendor": "vtex",
-  "version": "3.44.1",
+  "version": "3.44.2",
   "title": "address-form React component",
   "description": "address-form React component",
   "defaultLocale": "en",

--- a/react/country/VIR.ts
+++ b/react/country/VIR.ts
@@ -18,8 +18,8 @@ const rules: PostalCodeRules = {
       maxLength: 50,
       fixedLabel: 'ZIP',
       required: true,
-      mask: '99999-9999',
-      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)(-\d{4})?$',
+      mask: '99999',
+      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)(-\\d{4})?$',
       // Asserts zipcode starts with 008, then contains one of the local accepted area values, optionally followed by hyphen and exactly 4 digits.
       postalCodeAPI: true,
       forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',
@@ -61,16 +61,17 @@ const rules: PostalCodeRules = {
       size: 'large',
     },
     {
+      // Hidden field that no input ever fills: the postal code API returns an
+      // empty `state` for VIR and `defaultValue` is not applied automatically,
+      // so it must not be required nor restricted to options — otherwise the
+      // address never validates and checkout silently blocks (same pattern as
+      // the hidden `number` field above).
       name: 'state',
       maxLength: 100,
       label: 'state',
-      required: true,
       hidden: true,
       size: 'large',
-      optionsPairs: [
-        { label: 'Virgin Islands', value: 'USVI' },
-      ],
-      defaultValue: 'USVI'
+      defaultValue: 'VI',
     },
     {
       hidden: true,

--- a/react/country/VIR.ts
+++ b/react/country/VIR.ts
@@ -19,7 +19,7 @@ const rules: PostalCodeRules = {
       fixedLabel: 'ZIP',
       required: true,
       mask: '99999',
-      regex: '^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)(-\\d{4})?$',
+      regex: String.raw`^008(01|02|03|04|05|20|21|22|23|24|30|31|40|41|50|51)(-\d{4})?$`,
       // Asserts zipcode starts with 008, then contains one of the local accepted area values, optionally followed by hyphen and exactly 4 digits.
       postalCodeAPI: true,
       forgottenURL: 'https://tools.usps.com/go/ZipLookupAction!input.action',


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is a complementary fix to #699 since the changes done there were not enough to fix the issue.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
- Fixed Virgin Islands (VIR) address form not advancing to payment (`react/country/VIR.ts` only): corrected unescaped `\d` in the postal code regex string (was matching a literal `d` instead of digits); changed mask from `99999-9999` to `99999` to match the 5-digit USPS ZIP format; made the hidden `state` field non-blocking by removing `required` and `optionsPairs` and keeping `defaultValue: 'VI'` — the postal code API returns an empty `state` for VIR and `defaultValue` is never applied automatically, so the hidden required field could never be filled and silently failed validation, blocking checkout (verified that the checkout API accepts VIR addresses with both `state: 'VI'` and `state: null`).

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Testing workspace](https://testpostalcode--echidna.myvtex.com/checkout/#/shipping)

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
